### PR TITLE
Discard master/slave jargon

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -55,8 +55,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'nova'

--- a/nova/api/openstack/compute/contrib/extended_ips.py
+++ b/nova/api/openstack/compute/contrib/extended_ips.py
@@ -47,7 +47,7 @@ class ExtendedIpsController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedIpsServerTemplate())
             server = resp_obj.obj['server']
             db_instance = req.get_db_instance(server['id'])
@@ -59,7 +59,7 @@ class ExtendedIpsController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedIpsServersTemplate())
             servers = list(resp_obj.obj['servers'])
             for server in servers:
@@ -96,7 +96,7 @@ class ExtendedIpsServerTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('server', selector='server')
         xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(root)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_ips.alias: Extended_ips.namespace})
 
 
@@ -105,5 +105,5 @@ class ExtendedIpsServersTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('servers')
         elem = xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(elem)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_ips.alias: Extended_ips.namespace})

--- a/nova/api/openstack/compute/contrib/extended_ips_mac.py
+++ b/nova/api/openstack/compute/contrib/extended_ips_mac.py
@@ -45,7 +45,7 @@ class ExtendedIpsMacController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedIpsMacServerTemplate())
             server = resp_obj.obj['server']
             db_instance = req.get_db_instance(server['id'])
@@ -57,7 +57,7 @@ class ExtendedIpsMacController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedIpsMacServersTemplate())
             servers = list(resp_obj.obj['servers'])
             for server in servers:
@@ -93,7 +93,7 @@ class ExtendedIpsMacServerTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('server', selector='server')
         make_server(root)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_ips_mac.alias: Extended_ips_mac.namespace})
 
 
@@ -102,5 +102,5 @@ class ExtendedIpsMacServersTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('servers')
         elem = xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(elem)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_ips_mac.alias: Extended_ips_mac.namespace})

--- a/nova/api/openstack/compute/contrib/extended_server_attributes.py
+++ b/nova/api/openstack/compute/contrib/extended_server_attributes.py
@@ -39,7 +39,7 @@ class ExtendedServerAttributesController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedServerAttributeTemplate())
             server = resp_obj.obj['server']
             db_instance = req.get_db_instance(server['id'])
@@ -51,7 +51,7 @@ class ExtendedServerAttributesController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedServerAttributesTemplate())
 
             servers = list(resp_obj.obj['servers'])
@@ -92,7 +92,7 @@ class ExtendedServerAttributeTemplate(xmlutil.TemplateBuilder):
         make_server(root)
         alias = Extended_server_attributes.alias
         namespace = Extended_server_attributes.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})
 
 
 class ExtendedServerAttributesTemplate(xmlutil.TemplateBuilder):
@@ -102,4 +102,4 @@ class ExtendedServerAttributesTemplate(xmlutil.TemplateBuilder):
         make_server(elem)
         alias = Extended_server_attributes.alias
         namespace = Extended_server_attributes.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})

--- a/nova/api/openstack/compute/contrib/extended_status.py
+++ b/nova/api/openstack/compute/contrib/extended_status.py
@@ -36,7 +36,7 @@ class ExtendedStatusController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedStatusTemplate())
             server = resp_obj.obj['server']
             db_instance = req.get_db_instance(server['id'])
@@ -48,7 +48,7 @@ class ExtendedStatusController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedStatusesTemplate())
             servers = list(resp_obj.obj['servers'])
             for server in servers:
@@ -86,7 +86,7 @@ class ExtendedStatusTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('server', selector='server')
         make_server(root)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_status.alias: Extended_status.namespace})
 
 
@@ -95,5 +95,5 @@ class ExtendedStatusesTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('servers')
         elem = xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(elem)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_status.alias: Extended_status.namespace})

--- a/nova/api/openstack/compute/contrib/extended_virtual_interfaces_net.py
+++ b/nova/api/openstack/compute/contrib/extended_virtual_interfaces_net.py
@@ -33,7 +33,7 @@ class ExtendedVirtualInterfaceNetTemplate(xmlutil.TemplateBuilder):
         elem = xmlutil.SubTemplateElement(root, 'virtual_interface',
                                           selector='virtual_interfaces')
         make_vif(elem)
-        return xmlutil.SlaveTemplate(root, 1,
+        return xmlutil.SubordinateTemplate(root, 1,
                              nsmap={Extended_virtual_interfaces_net.alias:
                                     Extended_virtual_interfaces_net.namespace})
 
@@ -48,7 +48,7 @@ class ExtendedServerVIFNetController(wsgi.Controller):
         key = "%s:net_id" % Extended_virtual_interfaces_net.alias
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedVirtualInterfaceNetTemplate())
             for vif in resp_obj.obj['virtual_interfaces']:
                 vif1 = self.network_api.get_vif_by_mac_address(context,

--- a/nova/api/openstack/compute/contrib/extended_volumes.py
+++ b/nova/api/openstack/compute/contrib/extended_volumes.py
@@ -39,7 +39,7 @@ class ExtendedVolumesController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedVolumesServerTemplate())
             server = resp_obj.obj['server']
             db_instance = req.get_db_instance(server['id'])
@@ -51,7 +51,7 @@ class ExtendedVolumesController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedVolumesServersTemplate())
             servers = list(resp_obj.obj['servers'])
             for server in servers:
@@ -90,7 +90,7 @@ class ExtendedVolumesServerTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('server', selector='server')
         make_server(root)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_volumes.alias: Extended_volumes.namespace})
 
 
@@ -99,5 +99,5 @@ class ExtendedVolumesServersTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('servers')
         elem = xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(elem)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_volumes.alias: Extended_volumes.namespace})

--- a/nova/api/openstack/compute/contrib/flavor_access.py
+++ b/nova/api/openstack/compute/contrib/flavor_access.py
@@ -46,7 +46,7 @@ class FlavorTemplate(xmlutil.TemplateBuilder):
         make_flavor(root)
         alias = Flavor_access.alias
         namespace = Flavor_access.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})
 
 
 class FlavorsTemplate(xmlutil.TemplateBuilder):
@@ -56,7 +56,7 @@ class FlavorsTemplate(xmlutil.TemplateBuilder):
         make_flavor(elem)
         alias = Flavor_access.alias
         namespace = Flavor_access.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})
 
 
 class FlavorAccessTemplate(xmlutil.TemplateBuilder):
@@ -65,7 +65,7 @@ class FlavorAccessTemplate(xmlutil.TemplateBuilder):
         elem = xmlutil.SubTemplateElement(root, 'access',
                                           selector='flavor_access')
         make_flavor_access(elem)
-        return xmlutil.MasterTemplate(root, 1)
+        return xmlutil.MainTemplate(root, 1)
 
 
 def _marshall_flavor_access(flavor):
@@ -127,7 +127,7 @@ class FlavorActionController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if soft_authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=FlavorTemplate())
             db_flavor = req.get_db_flavor(id)
 
@@ -137,7 +137,7 @@ class FlavorActionController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if soft_authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=FlavorsTemplate())
 
             flavors = list(resp_obj.obj['flavors'])
@@ -149,7 +149,7 @@ class FlavorActionController(wsgi.Controller):
     def create(self, req, body, resp_obj):
         context = req.environ['nova.context']
         if soft_authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=FlavorTemplate())
 
             db_flavor = req.get_db_flavor(resp_obj.obj['flavor']['id'])

--- a/nova/api/openstack/compute/contrib/image_size.py
+++ b/nova/api/openstack/compute/contrib/image_size.py
@@ -29,7 +29,7 @@ class ImagesSizeTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('images')
         elem = xmlutil.SubTemplateElement(root, 'image', selector='images')
         make_image(elem)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Image_size.alias: Image_size.namespace})
 
 
@@ -37,7 +37,7 @@ class ImageSizeTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('image', selector='image')
         make_image(root)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Image_size.alias: Image_size.namespace})
 
 
@@ -51,7 +51,7 @@ class ImageSizeController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ["nova.context"]
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ImageSizeTemplate())
             image_resp = resp_obj.obj['image']
             # image guaranteed to be in the cache due to the core API adding
@@ -63,7 +63,7 @@ class ImageSizeController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ImagesSizeTemplate())
             images_resp = list(resp_obj.obj['images'])
             # images guaranteed to be in the cache due to the core API adding

--- a/nova/api/openstack/compute/contrib/server_usage.py
+++ b/nova/api/openstack/compute/contrib/server_usage.py
@@ -41,7 +41,7 @@ class ServerUsageController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ServerUsageTemplate())
             server = resp_obj.obj['server']
             db_instance = req.get_db_instance(server['id'])
@@ -53,7 +53,7 @@ class ServerUsageController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ServerUsagesTemplate())
             servers = list(resp_obj.obj['servers'])
             for server in servers:
@@ -89,7 +89,7 @@ class ServerUsageTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('server', selector='server')
         make_server(root)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Server_usage.alias: Server_usage.namespace})
 
 
@@ -98,5 +98,5 @@ class ServerUsagesTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('servers')
         elem = xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(elem)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Server_usage.alias: Server_usage.namespace})

--- a/nova/api/openstack/compute/servers.py
+++ b/nova/api/openstack/compute/servers.py
@@ -124,7 +124,7 @@ class ServerTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('server', selector='server')
         make_server(root, detailed=True)
-        return xmlutil.MasterTemplate(root, 1, nsmap=server_nsmap)
+        return xmlutil.MainTemplate(root, 1, nsmap=server_nsmap)
 
 
 class MinimalServersTemplate(xmlutil.TemplateBuilder):
@@ -133,7 +133,7 @@ class MinimalServersTemplate(xmlutil.TemplateBuilder):
         elem = xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(elem)
         xmlutil.make_links(root, 'servers_links')
-        return xmlutil.MasterTemplate(root, 1, nsmap=server_nsmap)
+        return xmlutil.MainTemplate(root, 1, nsmap=server_nsmap)
 
 
 class ServersTemplate(xmlutil.TemplateBuilder):
@@ -141,27 +141,27 @@ class ServersTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('servers')
         elem = xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(elem, detailed=True)
-        return xmlutil.MasterTemplate(root, 1, nsmap=server_nsmap)
+        return xmlutil.MainTemplate(root, 1, nsmap=server_nsmap)
 
 
 class ServerAdminPassTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('server')
         root.set('adminPass')
-        return xmlutil.SlaveTemplate(root, 1, nsmap=server_nsmap)
+        return xmlutil.SubordinateTemplate(root, 1, nsmap=server_nsmap)
 
 
 class ServerMultipleCreateTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('server')
         root.set('reservation_id')
-        return xmlutil.MasterTemplate(root, 1, nsmap=server_nsmap)
+        return xmlutil.MainTemplate(root, 1, nsmap=server_nsmap)
 
 
 def FullServerTemplate():
-    master = ServerTemplate()
-    master.attach(ServerAdminPassTemplate())
-    return master
+    main = ServerTemplate()
+    main.attach(ServerAdminPassTemplate())
+    return main
 
 
 class CommonDeserializer(wsgi.MetadataXMLDeserializer):

--- a/nova/api/openstack/wsgi.py
+++ b/nova/api/openstack/wsgi.py
@@ -584,7 +584,7 @@ class ResponseObject(object):
         self.serializer = serializer()
 
     def attach(self, **kwargs):
-        """Attach slave templates to serializers."""
+        """Attach subordinate templates to serializers."""
 
         if self.media_type in kwargs:
             self.serializer.attach(kwargs[self.media_type])

--- a/nova/api/openstack/xmlutil.py
+++ b/nova/api/openstack/xmlutil.py
@@ -672,13 +672,13 @@ class Template(object):
         # We are a template
         return self
 
-    def apply(self, master):
-        """Hook method for determining slave applicability.
+    def apply(self, main):
+        """Hook method for determining subordinate applicability.
 
         An overridable hook method used to determine if this template
-        is applicable as a slave to a given master template.
+        is applicable as a subordinate to a given main template.
 
-        :param master: The master template to test.
+        :param main: The main template to test.
         """
 
         return True
@@ -693,17 +693,17 @@ class Template(object):
         return "%r: %s" % (self, self.root.tree())
 
 
-class MasterTemplate(Template):
-    """Represent a master template.
+class MainTemplate(Template):
+    """Represent a main template.
 
-    Master templates are versioned derivatives of templates that
-    additionally allow slave templates to be attached.  Slave
+    Main templates are versioned derivatives of templates that
+    additionally allow subordinate templates to be attached.  Subordinate
     templates allow modification of the serialized result without
-    directly changing the master.
+    directly changing the main.
     """
 
     def __init__(self, root, version, nsmap=None):
-        """Initialize a master template.
+        """Initialize a main template.
 
         :param root: The root element of the template.
         :param version: The version number of the template.
@@ -712,9 +712,9 @@ class MasterTemplate(Template):
                       template.
         """
 
-        super(MasterTemplate, self).__init__(root, nsmap)
+        super(MainTemplate, self).__init__(root, nsmap)
         self.version = version
-        self.slaves = []
+        self.subordinates = []
 
     def __repr__(self):
         """Return string representation of the template."""
@@ -728,88 +728,88 @@ class MasterTemplate(Template):
 
         An overridable hook method to return the siblings of the root
         element.  This is the root element plus the root elements of
-        all the slave templates.
+        all the subordinate templates.
         """
 
-        return [self.root] + [slave.root for slave in self.slaves]
+        return [self.root] + [subordinate.root for subordinate in self.subordinates]
 
     def _nsmap(self):
         """Hook method for computing the namespace dictionary.
 
         An overridable hook method to return the namespace dictionary.
-        The namespace dictionary is computed by taking the master
+        The namespace dictionary is computed by taking the main
         template's namespace dictionary and updating it from all the
-        slave templates.
+        subordinate templates.
         """
 
         nsmap = self.nsmap.copy()
-        for slave in self.slaves:
-            nsmap.update(slave._nsmap())
+        for subordinate in self.subordinates:
+            nsmap.update(subordinate._nsmap())
         return nsmap
 
-    def attach(self, *slaves):
-        """Attach one or more slave templates.
+    def attach(self, *subordinates):
+        """Attach one or more subordinate templates.
 
-        Attaches one or more slave templates to the master template.
-        Slave templates must have a root element with the same tag as
-        the master template.  The slave template's apply() method will
-        be called to determine if the slave should be applied to this
-        master; if it returns False, that slave will be skipped.
-        (This allows filtering of slaves based on the version of the
-        master template.)
+        Attaches one or more subordinate templates to the main template.
+        Subordinate templates must have a root element with the same tag as
+        the main template.  The subordinate template's apply() method will
+        be called to determine if the subordinate should be applied to this
+        main; if it returns False, that subordinate will be skipped.
+        (This allows filtering of subordinates based on the version of the
+        main template.)
         """
 
-        slave_list = []
-        for slave in slaves:
-            slave = slave.wrap()
+        subordinate_list = []
+        for subordinate in subordinates:
+            subordinate = subordinate.wrap()
 
             # Make sure we have a tree match
-            if slave.root.tag != self.root.tag:
-                msg = _("Template tree mismatch; adding slave %(slavetag)s to "
-                        "master %(mastertag)s") % {'slavetag': slave.root.tag,
-                                                   'mastertag': self.root.tag}
+            if subordinate.root.tag != self.root.tag:
+                msg = _("Template tree mismatch; adding subordinate %(subordinatetag)s to "
+                        "main %(maintag)s") % {'subordinatetag': subordinate.root.tag,
+                                                   'maintag': self.root.tag}
                 raise ValueError(msg)
 
-            # Make sure slave applies to this template
-            if not slave.apply(self):
+            # Make sure subordinate applies to this template
+            if not subordinate.apply(self):
                 continue
 
-            slave_list.append(slave)
+            subordinate_list.append(subordinate)
 
-        # Add the slaves
-        self.slaves.extend(slave_list)
+        # Add the subordinates
+        self.subordinates.extend(subordinate_list)
 
     def copy(self):
-        """Return a copy of this master template."""
+        """Return a copy of this main template."""
 
-        # Return a copy of the MasterTemplate
+        # Return a copy of the MainTemplate
         tmp = self.__class__(self.root, self.version, self.nsmap)
-        tmp.slaves = self.slaves[:]
+        tmp.subordinates = self.subordinates[:]
         return tmp
 
 
-class SlaveTemplate(Template):
-    """Represent a slave template.
+class SubordinateTemplate(Template):
+    """Represent a subordinate template.
 
-    Slave templates are versioned derivatives of templates.  Each
-    slave has a minimum version and optional maximum version of the
-    master template to which they can be attached.
+    Subordinate templates are versioned derivatives of templates.  Each
+    subordinate has a minimum version and optional maximum version of the
+    main template to which they can be attached.
     """
 
     def __init__(self, root, min_vers, max_vers=None, nsmap=None):
-        """Initialize a slave template.
+        """Initialize a subordinate template.
 
         :param root: The root element of the template.
-        :param min_vers: The minimum permissible version of the master
-                         template for this slave template to apply.
-        :param max_vers: An optional upper bound for the master
+        :param min_vers: The minimum permissible version of the main
+                         template for this subordinate template to apply.
+        :param max_vers: An optional upper bound for the main
                          template version.
         :param nsmap: An optional namespace dictionary to be
                       associated with the root element of the
                       template.
         """
 
-        super(SlaveTemplate, self).__init__(root, nsmap)
+        super(SubordinateTemplate, self).__init__(root, nsmap)
         self.min_vers = min_vers
         self.max_vers = max_vers
 
@@ -820,23 +820,23 @@ class SlaveTemplate(Template):
                 (self.__class__.__module__, self.__class__.__name__,
                  self.min_vers, self.max_vers, id(self)))
 
-    def apply(self, master):
-        """Hook method for determining slave applicability.
+    def apply(self, main):
+        """Hook method for determining subordinate applicability.
 
         An overridable hook method used to determine if this template
-        is applicable as a slave to a given master template.  This
-        version requires the master template to have a version number
+        is applicable as a subordinate to a given main template.  This
+        version requires the main template to have a version number
         between min_vers and max_vers.
 
-        :param master: The master template to test.
+        :param main: The main template to test.
         """
 
-        # Does the master meet our minimum version requirement?
-        if master.version < self.min_vers:
+        # Does the main meet our minimum version requirement?
+        if main.version < self.min_vers:
             return False
 
         # How about our maximum version requirement?
-        if self.max_vers is not None and master.version > self.max_vers:
+        if self.max_vers is not None and main.version > self.max_vers:
             return False
 
         return True

--- a/nova/compute/rpcapi.py
+++ b/nova/compute/rpcapi.py
@@ -148,7 +148,7 @@ class ComputeAPI(object):
 
         * 2.0 - Remove 1.x backwards compat
         * 2.1 - Adds orig_sys_metadata to rebuild_instance()
-        * 2.2 - Adds slave_info parameter to add_aggregate_host() and
+        * 2.2 - Adds subordinate_info parameter to add_aggregate_host() and
                 remove_aggregate_host()
         * 2.3 - Adds volume_id to reserve_block_device_name()
         * 2.4 - Add bdms to terminate_instance
@@ -307,7 +307,7 @@ class ComputeAPI(object):
             raise exception.LiveMigrationWithOldNovaNotSafe(server=server)
 
     def add_aggregate_host(self, ctxt, aggregate, host_param, host,
-                           slave_info=None):
+                           subordinate_info=None):
         '''Add aggregate host.
 
         :param ctxt: request context
@@ -328,7 +328,7 @@ class ComputeAPI(object):
         cctxt = self.client.prepare(server=host, version=version)
         cctxt.cast(ctxt, 'add_aggregate_host',
                    aggregate=aggregate, host=host_param,
-                   slave_info=slave_info)
+                   subordinate_info=subordinate_info)
 
     def add_fixed_ip_to_instance(self, ctxt, instance, network_id):
         if self.client.can_send_version('3.12'):
@@ -696,7 +696,7 @@ class ComputeAPI(object):
         cctxt.cast(ctxt, 'refresh_provider_fw_rules')
 
     def remove_aggregate_host(self, ctxt, aggregate, host_param, host,
-                              slave_info=None):
+                              subordinate_info=None):
         '''Remove aggregate host.
 
         :param ctxt: request context
@@ -717,7 +717,7 @@ class ComputeAPI(object):
         cctxt = self.client.prepare(server=host, version=version)
         cctxt.cast(ctxt, 'remove_aggregate_host',
                    aggregate=aggregate, host=host_param,
-                   slave_info=slave_info)
+                   subordinate_info=subordinate_info)
 
     def remove_fixed_ip_from_instance(self, ctxt, instance, address):
         if self.client.can_send_version('3.13'):

--- a/nova/conductor/manager.py
+++ b/nova/conductor/manager.py
@@ -218,10 +218,10 @@ class ConductorManager(manager.Manager):
 
     def instance_get_all_by_filters(self, context, filters, sort_key,
                                     sort_dir, columns_to_join,
-                                    use_slave):
+                                    use_subordinate):
         result = self.db.instance_get_all_by_filters(
             context, filters, sort_key, sort_dir,
-            columns_to_join=columns_to_join, use_slave=use_slave)
+            columns_to_join=columns_to_join, use_subordinate=use_subordinate)
         return jsonutils.to_primitive(result)
 
     def instance_get_active_by_window(self, context, begin, end,

--- a/nova/conductor/rpcapi.py
+++ b/nova/conductor/rpcapi.py
@@ -124,7 +124,7 @@ class ConductorAPI(object):
     * 1.62 - Added object_backport()
     * 1.63 - Changed the format of values['stats'] from a dict to a JSON string
              in compute_node_update()
-    * 1.64 - Added use_slave to instance_get_all_filters()
+    * 1.64 - Added use_subordinate to instance_get_all_filters()
            - Remove instance_type_get()
            - Remove aggregate_get()
            - Remove aggregate_get_by_host()

--- a/nova/console/xvp.py
+++ b/nova/console/xvp.py
@@ -40,7 +40,7 @@ xvp_opts = [
                help='Generated XVP conf file'),
     cfg.StrOpt('console_xvp_pid',
                default='/var/run/xvp.pid',
-               help='XVP master process pid file'),
+               help='XVP main process pid file'),
     cfg.StrOpt('console_xvp_log',
                default='/var/log/xvp.log',
                help='XVP log file'),

--- a/nova/db/api.py
+++ b/nova/db/api.py
@@ -484,12 +484,12 @@ def migration_get_by_instance_and_status(context, instance_uuid, status):
 
 
 def migration_get_unconfirmed_by_dest_compute(context, confirm_window,
-        dest_compute, use_slave=False):
+        dest_compute, use_subordinate=False):
     """Finds all unconfirmed migrations within the confirmation window for
     a specific destination compute host.
     """
     return IMPL.migration_get_unconfirmed_by_dest_compute(context,
-            confirm_window, dest_compute, use_slave=use_slave)
+            confirm_window, dest_compute, use_subordinate=use_subordinate)
 
 
 def migration_get_in_progress_by_host_and_node(context, host, node):
@@ -626,10 +626,10 @@ def virtual_interface_get_by_uuid(context, vif_uuid):
     return IMPL.virtual_interface_get_by_uuid(context, vif_uuid)
 
 
-def virtual_interface_get_by_instance(context, instance_id, use_slave=False):
+def virtual_interface_get_by_instance(context, instance_id, use_subordinate=False):
     """Gets all virtual_interfaces for instance."""
     return IMPL.virtual_interface_get_by_instance(context, instance_id,
-                                                  use_slave=use_slave)
+                                                  use_subordinate=use_subordinate)
 
 
 def virtual_interface_get_by_instance_and_network(context, instance_id,
@@ -670,10 +670,10 @@ def instance_destroy(context, instance_uuid, constraint=None,
     return rv
 
 
-def instance_get_by_uuid(context, uuid, columns_to_join=None, use_slave=False):
+def instance_get_by_uuid(context, uuid, columns_to_join=None, use_subordinate=False):
     """Get an instance or raise if it does not exist."""
     return IMPL.instance_get_by_uuid(context, uuid,
-                                     columns_to_join, use_slave=use_slave)
+                                     columns_to_join, use_subordinate=use_subordinate)
 
 
 def instance_get(context, instance_id, columns_to_join=None):
@@ -689,13 +689,13 @@ def instance_get_all(context, columns_to_join=None):
 
 def instance_get_all_by_filters(context, filters, sort_key='created_at',
                                 sort_dir='desc', limit=None, marker=None,
-                                columns_to_join=None, use_slave=False):
+                                columns_to_join=None, use_subordinate=False):
     """Get all instances that match all filters."""
     return IMPL.instance_get_all_by_filters(context, filters, sort_key,
                                             sort_dir, limit=limit,
                                             marker=marker,
                                             columns_to_join=columns_to_join,
-                                            use_slave=use_slave)
+                                            use_subordinate=use_subordinate)
 
 
 def instance_get_active_by_window_joined(context, begin, end=None,
@@ -710,11 +710,11 @@ def instance_get_active_by_window_joined(context, begin, end=None,
 
 
 def instance_get_all_by_host(context, host,
-                             columns_to_join=None, use_slave=False):
+                             columns_to_join=None, use_subordinate=False):
     """Get all instances belonging to a host."""
     return IMPL.instance_get_all_by_host(context, host,
                                          columns_to_join,
-                                         use_slave=use_slave)
+                                         use_subordinate=use_subordinate)
 
 
 def instance_get_all_by_host_and_node(context, host, node):
@@ -1220,11 +1220,11 @@ def block_device_mapping_update_or_create(context, values, legacy=True):
 
 
 def block_device_mapping_get_all_by_instance(context, instance_uuid,
-                                             use_slave=False):
+                                             use_subordinate=False):
     """Get all block device mapping belonging to an instance."""
     return IMPL.block_device_mapping_get_all_by_instance(context,
                                                          instance_uuid,
-                                                         use_slave)
+                                                         use_subordinate)
 
 
 def block_device_mapping_get_by_volume_id(context, volume_id,
@@ -1656,7 +1656,7 @@ def agent_build_update(context, agent_build_id, values):
 ####################
 
 
-def bw_usage_get(context, uuid, start_period, mac, use_slave=False):
+def bw_usage_get(context, uuid, start_period, mac, use_subordinate=False):
     """Return bw usage for instance and mac in a given audit period."""
     return IMPL.bw_usage_get(context, uuid, start_period, mac)
 

--- a/nova/db/sqlalchemy/api.py
+++ b/nova/db/sqlalchemy/api.py
@@ -74,10 +74,10 @@ db_opts = [
 ]
 
 connection_opts = [
-    cfg.StrOpt('slave_connection',
+    cfg.StrOpt('subordinate_connection',
                secret=True,
                help='The SQLAlchemy connection string used to connect to the '
-                    'slave database'),
+                    'subordinate database'),
 ]
 
 CONF = cfg.CONF
@@ -95,12 +95,12 @@ _MASTER_FACADE = None
 _SLAVE_FACADE = None
 
 
-def _create_facade_lazily(use_slave=False):
+def _create_facade_lazily(use_subordinate=False):
     global _MASTER_FACADE
     global _SLAVE_FACADE
 
-    return_slave = use_slave and CONF.database.slave_connection
-    if not return_slave:
+    return_subordinate = use_subordinate and CONF.database.subordinate_connection
+    if not return_subordinate:
         if _MASTER_FACADE is None:
             _MASTER_FACADE = db_session.EngineFacade(
                 CONF.database.connection,
@@ -110,19 +110,19 @@ def _create_facade_lazily(use_slave=False):
     else:
         if _SLAVE_FACADE is None:
             _SLAVE_FACADE = db_session.EngineFacade(
-                CONF.database.slave_connection,
+                CONF.database.subordinate_connection,
                 **dict(CONF.database.iteritems())
             )
         return _SLAVE_FACADE
 
 
-def get_engine(use_slave=False):
-    facade = _create_facade_lazily(use_slave)
+def get_engine(use_subordinate=False):
+    facade = _create_facade_lazily(use_subordinate)
     return facade.get_engine()
 
 
-def get_session(use_slave=False, **kwargs):
-    facade = _create_facade_lazily(use_slave)
+def get_session(use_subordinate=False, **kwargs):
+    facade = _create_facade_lazily(use_subordinate)
     return facade.get_session(**kwargs)
 
 
@@ -218,7 +218,7 @@ def model_query(context, model, *args, **kwargs):
     """Query helper that accounts for context's `read_deleted` field.
 
     :param context: context to query under
-    :param use_slave: If true, use slave_connection
+    :param use_subordinate: If true, use subordinate_connection
     :param session: if present, the session to use
     :param read_deleted: if present, overrides context's read_deleted field.
     :param project_only: if present and context is user-type, then restrict
@@ -230,11 +230,11 @@ def model_query(context, model, *args, **kwargs):
             model parameter.
     """
 
-    use_slave = kwargs.get('use_slave') or False
-    if CONF.database.slave_connection == '':
-        use_slave = False
+    use_subordinate = kwargs.get('use_subordinate') or False
+    if CONF.database.subordinate_connection == '':
+        use_subordinate = False
 
-    session = kwargs.get('session') or get_session(use_slave=use_slave)
+    session = kwargs.get('session') or get_session(use_subordinate=use_subordinate)
     read_deleted = kwargs.get('read_deleted') or context.read_deleted
     project_only = kwargs.get('project_only', False)
 
@@ -1453,9 +1453,9 @@ def virtual_interface_create(context, values):
     return vif_ref
 
 
-def _virtual_interface_query(context, session=None, use_slave=False):
+def _virtual_interface_query(context, session=None, use_subordinate=False):
     return model_query(context, models.VirtualInterface, session=session,
-                       read_deleted="no", use_slave=use_slave)
+                       read_deleted="no", use_subordinate=use_subordinate)
 
 
 @require_context
@@ -1501,12 +1501,12 @@ def virtual_interface_get_by_uuid(context, vif_uuid):
 
 @require_context
 @require_instance_exists_using_uuid
-def virtual_interface_get_by_instance(context, instance_uuid, use_slave=False):
+def virtual_interface_get_by_instance(context, instance_uuid, use_subordinate=False):
     """Gets all virtual interfaces for instance.
 
     :param instance_uuid: = uuid of the instance to retrieve vifs for
     """
-    vif_refs = _virtual_interface_query(context, use_slave=use_slave).\
+    vif_refs = _virtual_interface_query(context, use_subordinate=use_subordinate).\
                        filter_by(instance_uuid=instance_uuid).\
                        order_by(asc("created_at"), asc("id")).\
                        all()
@@ -1703,16 +1703,16 @@ def instance_destroy(context, instance_uuid, constraint=None):
 
 
 @require_context
-def instance_get_by_uuid(context, uuid, columns_to_join=None, use_slave=False):
+def instance_get_by_uuid(context, uuid, columns_to_join=None, use_subordinate=False):
     return _instance_get_by_uuid(context, uuid,
-            columns_to_join=columns_to_join, use_slave=use_slave)
+            columns_to_join=columns_to_join, use_subordinate=use_subordinate)
 
 
 def _instance_get_by_uuid(context, uuid, session=None,
-                          columns_to_join=None, use_slave=False):
+                          columns_to_join=None, use_subordinate=False):
     result = _build_instance_get(context, session=session,
                                  columns_to_join=columns_to_join,
-                                 use_slave=use_slave).\
+                                 use_subordinate=use_subordinate).\
                 filter_by(uuid=uuid).\
                 first()
 
@@ -1741,9 +1741,9 @@ def instance_get(context, instance_id, columns_to_join=None):
 
 
 def _build_instance_get(context, session=None,
-                        columns_to_join=None, use_slave=False):
+                        columns_to_join=None, use_subordinate=False):
     query = model_query(context, models.Instance, session=session,
-                        project_only=True, use_slave=use_slave).\
+                        project_only=True, use_subordinate=use_subordinate).\
             options(joinedload_all('security_groups.rules')).\
             options(joinedload('info_cache'))
     if columns_to_join is None:
@@ -1761,7 +1761,7 @@ def _build_instance_get(context, session=None,
 
 
 def _instances_fill_metadata(context, instances,
-                             manual_joins=None, use_slave=False):
+                             manual_joins=None, use_subordinate=False):
     """Selectively fill instances with manually-joined metadata. Note that
     instance will be converted to a dict.
 
@@ -1779,13 +1779,13 @@ def _instances_fill_metadata(context, instances,
     meta = collections.defaultdict(list)
     if 'metadata' in manual_joins:
         for row in _instance_metadata_get_multi(context, uuids,
-                                                use_slave=use_slave):
+                                                use_subordinate=use_subordinate):
             meta[row['instance_uuid']].append(row)
 
     sys_meta = collections.defaultdict(list)
     if 'system_metadata' in manual_joins:
         for row in _instance_system_metadata_get_multi(context, uuids,
-                                                       use_slave=use_slave):
+                                                       use_subordinate=use_subordinate):
             sys_meta[row['instance_uuid']].append(row)
 
     pcidevs = collections.defaultdict(list)
@@ -1837,7 +1837,7 @@ def instance_get_all(context, columns_to_join=None):
 @require_context
 def instance_get_all_by_filters(context, filters, sort_key, sort_dir,
                                 limit=None, marker=None, columns_to_join=None,
-                                use_slave=False):
+                                use_subordinate=False):
     """Return instances that match all filters.  Deleted instances
     will be returned by default, unless there's a filter that says
     otherwise.
@@ -1879,10 +1879,10 @@ def instance_get_all_by_filters(context, filters, sort_key, sort_dir,
 
     sort_fn = {'desc': desc, 'asc': asc}
 
-    if CONF.database.slave_connection == '':
-        use_slave = False
+    if CONF.database.subordinate_connection == '':
+        use_subordinate = False
 
-    session = get_session(use_slave=use_slave)
+    session = get_session(use_subordinate=use_subordinate)
 
     if columns_to_join is None:
         columns_to_join = ['info_cache', 'security_groups']
@@ -2090,14 +2090,14 @@ def instance_get_active_by_window_joined(context, begin, end=None,
 
 
 def _instance_get_all_query(context, project_only=False,
-                            joins=None, use_slave=False):
+                            joins=None, use_subordinate=False):
     if joins is None:
         joins = ['info_cache', 'security_groups']
 
     query = model_query(context,
                         models.Instance,
                         project_only=project_only,
-                        use_slave=use_slave)
+                        use_subordinate=use_subordinate)
     for join in joins:
         query = query.options(joinedload(join))
     return query
@@ -2106,12 +2106,12 @@ def _instance_get_all_query(context, project_only=False,
 @require_admin_context
 def instance_get_all_by_host(context, host,
                              columns_to_join=None,
-                             use_slave=False):
+                             use_subordinate=False):
     return _instances_fill_metadata(context,
       _instance_get_all_query(context,
-                              use_slave=use_slave).filter_by(host=host).all(),
+                              use_subordinate=use_subordinate).filter_by(host=host).all(),
                               manual_joins=columns_to_join,
-                              use_slave=use_slave)
+                              use_subordinate=use_subordinate)
 
 
 def _instance_get_all_uuids_by_host(context, host, session=None):
@@ -3480,12 +3480,12 @@ def ec2_snapshot_get_by_uuid(context, snapshot_uuid):
 
 
 def _block_device_mapping_get_query(context, session=None,
-        columns_to_join=None, use_slave=False):
+        columns_to_join=None, use_subordinate=False):
     if columns_to_join is None:
         columns_to_join = []
 
     query = model_query(context, models.BlockDeviceMapping,
-                        session=session, use_slave=use_slave)
+                        session=session, use_subordinate=use_subordinate)
 
     for column in columns_to_join:
         query = query.options(joinedload(column))
@@ -3567,8 +3567,8 @@ def block_device_mapping_update_or_create(context, values, legacy=True):
 
 @require_context
 def block_device_mapping_get_all_by_instance(context, instance_uuid,
-                                             use_slave=False):
-    return _block_device_mapping_get_query(context, use_slave=use_slave).\
+                                             use_subordinate=False):
+    return _block_device_mapping_get_query(context, use_subordinate=use_subordinate).\
                  filter_by(instance_uuid=instance_uuid).\
                  all()
 
@@ -4073,12 +4073,12 @@ def migration_get_by_instance_and_status(context, instance_uuid, status):
 
 @require_admin_context
 def migration_get_unconfirmed_by_dest_compute(context, confirm_window,
-                                              dest_compute, use_slave=False):
+                                              dest_compute, use_subordinate=False):
     confirm_window = (timeutils.utcnow() -
                       datetime.timedelta(seconds=confirm_window))
 
     return model_query(context, models.Migration, read_deleted="yes",
-                       use_slave=use_slave).\
+                       use_subordinate=use_subordinate).\
              filter(models.Migration.updated_at <= confirm_window).\
              filter_by(status="finished").\
              filter_by(dest_compute=dest_compute).\
@@ -4597,11 +4597,11 @@ def cell_get_all(context):
 # User-provided metadata
 
 def _instance_metadata_get_multi(context, instance_uuids,
-                                 session=None, use_slave=False):
+                                 session=None, use_subordinate=False):
     if not instance_uuids:
         return []
     return model_query(context, models.InstanceMetadata,
-                       session=session, use_slave=use_slave).\
+                       session=session, use_subordinate=use_subordinate).\
                     filter(
             models.InstanceMetadata.instance_uuid.in_(instance_uuids))
 
@@ -4663,11 +4663,11 @@ def instance_metadata_update(context, instance_uuid, metadata, delete):
 
 
 def _instance_system_metadata_get_multi(context, instance_uuids,
-                                        session=None, use_slave=False):
+                                        session=None, use_subordinate=False):
     if not instance_uuids:
         return []
     return model_query(context, models.InstanceSystemMetadata,
-                       session=session, use_slave=use_slave).\
+                       session=session, use_subordinate=use_subordinate).\
                     filter(
             models.InstanceSystemMetadata.instance_uuid.in_(instance_uuids))
 
@@ -4770,9 +4770,9 @@ def agent_build_update(context, agent_build_id, values):
 ####################
 
 @require_context
-def bw_usage_get(context, uuid, start_period, mac, use_slave=False):
+def bw_usage_get(context, uuid, start_period, mac, use_subordinate=False):
     return model_query(context, models.BandwidthUsage, read_deleted="yes",
-                       use_slave=use_slave).\
+                       use_subordinate=use_subordinate).\
                            filter_by(start_period=start_period).\
                            filter_by(uuid=uuid).\
                            filter_by(mac=mac).\

--- a/nova/network/ldapdns.py
+++ b/nova/network/ldapdns.py
@@ -42,9 +42,9 @@ ldap_dns_opts = [
                default='password',
                help='Password for LDAP DNS',
                secret=True),
-    cfg.StrOpt('ldap_dns_soa_hostmaster',
-               default='hostmaster@example.org',
-               help='Hostmaster for LDAP DNS driver Statement of Authority'),
+    cfg.StrOpt('ldap_dns_soa_hostmain',
+               default='hostmain@example.org',
+               help='Hostmain for LDAP DNS driver Statement of Authority'),
     cfg.MultiStrOpt('ldap_dns_servers',
                     default=['dns.example.org'],
                     help='DNS Servers for LDAP DNS driver'),
@@ -156,7 +156,7 @@ class DomainEntry(DNSEntry):
         date = time.strftime('%Y%m%d%H%M%S')
         soa = '%s %s %s %s %s %s %s' % (
                  CONF.ldap_dns_servers[0],
-                 CONF.ldap_dns_soa_hostmaster,
+                 CONF.ldap_dns_soa_hostmain,
                  date,
                  CONF.ldap_dns_soa_refresh,
                  CONF.ldap_dns_soa_retry,

--- a/nova/network/linux_net.py
+++ b/nova/network/linux_net.py
@@ -1570,7 +1570,7 @@ class LinuxBridgeInterfaceDriver(LinuxNetInterfaceDriver):
             out, err = _execute('brctl', 'addif', bridge, interface,
                                 check_exit_code=False, run_as_root=True)
             if (err and err != "device %s is already a member of a bridge; "
-                     "can't enslave it to bridge %s.\n" % (interface, bridge)):
+                     "can't ensubordinate it to bridge %s.\n" % (interface, bridge)):
                 msg = _('Failed to add interface: %s') % err
                 raise exception.NovaException(msg)
 

--- a/nova/network/manager.py
+++ b/nova/network/manager.py
@@ -568,7 +568,7 @@ class NetworkManager(manager.Manager):
         where network = dict containing pertinent data from a network db object
         and info = dict containing pertinent networking data
         """
-        use_slave = kwargs.get('use_slave') or False
+        use_subordinate = kwargs.get('use_subordinate') or False
 
         if not uuidutils.is_uuid_like(instance_id):
             instance_id = instance_uuid
@@ -576,7 +576,7 @@ class NetworkManager(manager.Manager):
         LOG.debug('Get instance network info', instance_uuid=instance_uuid)
 
         vifs = objects.VirtualInterfaceList.get_by_instance_uuid(
-                context, instance_uuid, use_slave=use_slave)
+                context, instance_uuid, use_subordinate=use_subordinate)
         networks = {}
 
         for vif in vifs:

--- a/nova/network/neutronv2/api.py
+++ b/nova/network/neutronv2/api.py
@@ -535,13 +535,13 @@ class API(base_api.NetworkAPI):
         return neutronv2.get_client(context).show_port(port_id)
 
     def get_instance_nw_info(self, context, instance, networks=None,
-                             port_ids=None, use_slave=False):
+                             port_ids=None, use_subordinate=False):
         """Return network information for specified instance
            and update cache.
         """
-        # NOTE(geekinutah): It would be nice if use_slave had us call
-        #                   special APIs that pummeled slaves instead of
-        #                   the master. For now we just ignore this arg.
+        # NOTE(geekinutah): It would be nice if use_subordinate had us call
+        #                   special APIs that pummeled subordinates instead of
+        #                   the main. For now we just ignore this arg.
         result = self._get_instance_nw_info(context, instance, networks,
                                             port_ids)
         base_api.update_instance_cache_with_nw_info(self, context, instance,

--- a/nova/objects/block_device.py
+++ b/nova/objects/block_device.py
@@ -188,7 +188,7 @@ class BlockDeviceMapping(base.NovaPersistentObject, base.NovaObject):
 class BlockDeviceMappingList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
     # Version 1.1: BlockDeviceMapping <= version 1.1
-    # Version 1.2: Added use_slave to get_by_instance_uuid
+    # Version 1.2: Added use_subordinate to get_by_instance_uuid
     VERSION = '1.2'
 
     fields = {
@@ -201,9 +201,9 @@ class BlockDeviceMappingList(base.ObjectListBase, base.NovaObject):
     }
 
     @base.remotable_classmethod
-    def get_by_instance_uuid(cls, context, instance_uuid, use_slave=False):
+    def get_by_instance_uuid(cls, context, instance_uuid, use_subordinate=False):
         db_bdms = db.block_device_mapping_get_all_by_instance(
-                context, instance_uuid, use_slave=use_slave)
+                context, instance_uuid, use_subordinate=use_subordinate)
         return base.obj_make_list(
                 context, cls(), objects.BlockDeviceMapping, db_bdms or [])
 

--- a/nova/objects/instance.py
+++ b/nova/objects/instance.py
@@ -68,7 +68,7 @@ class Instance(base.NovaPersistentObject, base.NovaObject):
     # Version 1.7: String attributes updated to support unicode
     # Version 1.8: 'security_groups' and 'pci_devices' cannot be None
     # Version 1.9: Make uuid a non-None real string
-    # Version 1.10: Added use_slave to refresh and get_by_uuid
+    # Version 1.10: Added use_subordinate to refresh and get_by_uuid
     # Version 1.11: Update instance from database during destroy
     # Version 1.12: Added ephemeral_key_uuid
     # Version 1.13: Added delete_metadata_key()
@@ -301,13 +301,13 @@ class Instance(base.NovaPersistentObject, base.NovaObject):
         return instance
 
     @base.remotable_classmethod
-    def get_by_uuid(cls, context, uuid, expected_attrs=None, use_slave=False):
+    def get_by_uuid(cls, context, uuid, expected_attrs=None, use_subordinate=False):
         if expected_attrs is None:
             expected_attrs = ['info_cache', 'security_groups']
         columns_to_join = _expected_cols(expected_attrs)
         db_inst = db.instance_get_by_uuid(context, uuid,
                                           columns_to_join=columns_to_join,
-                                          use_slave=use_slave)
+                                          use_subordinate=use_subordinate)
         return cls._from_db_object(context, cls(), db_inst,
                                    expected_attrs)
 
@@ -481,12 +481,12 @@ class Instance(base.NovaPersistentObject, base.NovaObject):
         self.obj_reset_changes()
 
     @base.remotable
-    def refresh(self, context, use_slave=False):
+    def refresh(self, context, use_subordinate=False):
         extra = [field for field in INSTANCE_OPTIONAL_ATTRS
                        if self.obj_attr_is_set(field)]
         current = self.__class__.get_by_uuid(context, uuid=self.uuid,
                                              expected_attrs=extra,
-                                             use_slave=use_slave)
+                                             use_subordinate=use_subordinate)
         # NOTE(danms): We orphan the instance copy so we do not unexpectedly
         # trigger a lazy-load (which would mean we failed to calculate the
         # expected_attrs properly)
@@ -609,10 +609,10 @@ def _make_instance_list(context, inst_list, db_inst_list, expected_attrs):
 
 class InstanceList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
-    # Version 1.1: Added use_slave to get_by_host
+    # Version 1.1: Added use_subordinate to get_by_host
     #              Instance <= version 1.9
     # Version 1.2: Instance <= version 1.11
-    # Version 1.3: Added use_slave to get_by_filters
+    # Version 1.3: Added use_subordinate to get_by_filters
     # Version 1.4: Instance <= version 1.12
     # Version 1.5: Added method get_active_by_window_joined.
     # Version 1.6: Instance <= version 1.13
@@ -634,19 +634,19 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     @base.remotable_classmethod
     def get_by_filters(cls, context, filters,
                        sort_key='created_at', sort_dir='desc', limit=None,
-                       marker=None, expected_attrs=None, use_slave=False):
+                       marker=None, expected_attrs=None, use_subordinate=False):
         db_inst_list = db.instance_get_all_by_filters(
             context, filters, sort_key, sort_dir, limit=limit, marker=marker,
             columns_to_join=_expected_cols(expected_attrs),
-            use_slave=use_slave)
+            use_subordinate=use_subordinate)
         return _make_instance_list(context, cls(), db_inst_list,
                                    expected_attrs)
 
     @base.remotable_classmethod
-    def get_by_host(cls, context, host, expected_attrs=None, use_slave=False):
+    def get_by_host(cls, context, host, expected_attrs=None, use_subordinate=False):
         db_inst_list = db.instance_get_all_by_host(
             context, host, columns_to_join=_expected_cols(expected_attrs),
-            use_slave=use_slave)
+            use_subordinate=use_subordinate)
         return _make_instance_list(context, cls(), db_inst_list,
                                    expected_attrs)
 

--- a/nova/objects/migration.py
+++ b/nova/objects/migration.py
@@ -81,7 +81,7 @@ class Migration(base.NovaPersistentObject, base.NovaObject):
 class MigrationList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
     #              Migration <= 1.1
-    # Version 1.1: Added use_slave to get_unconfirmed_by_dest_compute
+    # Version 1.1: Added use_subordinate to get_unconfirmed_by_dest_compute
     VERSION = '1.1'
 
     fields = {
@@ -95,9 +95,9 @@ class MigrationList(base.ObjectListBase, base.NovaObject):
 
     @base.remotable_classmethod
     def get_unconfirmed_by_dest_compute(cls, context, confirm_window,
-                                        dest_compute, use_slave=False):
+                                        dest_compute, use_subordinate=False):
         db_migrations = db.migration_get_unconfirmed_by_dest_compute(
-            context, confirm_window, dest_compute, use_slave=use_slave)
+            context, confirm_window, dest_compute, use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(context), objects.Migration,
                                   db_migrations)
 

--- a/nova/objects/virtual_interface.py
+++ b/nova/objects/virtual_interface.py
@@ -95,8 +95,8 @@ class VirtualInterfaceList(base.ObjectListBase, base.NovaObject):
                                   objects.VirtualInterface, db_vifs)
 
     @base.remotable_classmethod
-    def get_by_instance_uuid(cls, context, instance_uuid, use_slave=False):
+    def get_by_instance_uuid(cls, context, instance_uuid, use_subordinate=False):
         db_vifs = db.virtual_interface_get_by_instance(context, instance_uuid,
-                use_slave=use_slave)
+                use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(context),
                                   objects.VirtualInterface, db_vifs)

--- a/nova/openstack/common/db/sqlalchemy/migration.py
+++ b/nova/openstack/common/db/sqlalchemy/migration.py
@@ -64,7 +64,7 @@ def _get_unique_constraints(self, table):
 
     data = table.metadata.bind.execute(
         """SELECT sql
-           FROM sqlite_master
+           FROM sqlite_main
            WHERE
                type='table' AND
                name=:table_name""",

--- a/nova/openstack/common/gettextutils.py
+++ b/nova/openstack/common/gettextutils.py
@@ -331,9 +331,9 @@ def get_available_languages(domain):
     # order matters) since our in-line message strings are en_US
     language_list = ['en_US']
     # NOTE(luisg): Babel <1.0 used a function called list(), which was
-    # renamed to locale_identifiers() in >=1.0, the requirements master list
+    # renamed to locale_identifiers() in >=1.0, the requirements main list
     # requires >=0.9.6, uncapped, so defensively work with both. We can remove
-    # this check when the master list updates to >=1.0, and update all projects
+    # this check when the main list updates to >=1.0, and update all projects
     list_identifiers = (getattr(localedata, 'list', None) or
                         getattr(localedata, 'locale_identifiers'))
     locale_identifiers = list_identifiers()

--- a/nova/tests/api/ec2/test_cloud.py
+++ b/nova/tests/api/ec2/test_cloud.py
@@ -2516,7 +2516,7 @@ class CloudTestCase(test.TestCase):
         self.stubs.Set(fake._FakeImageService, 'show', fake_show)
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': volumes[0],
                          'snapshot_id': snapshots[0],
@@ -2591,7 +2591,7 @@ class CloudTestCase(test.TestCase):
         ec2_instance_id = self._run_instance(**kwargs)
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': volumes[0],
                          'snapshot_id': snapshots[0],
@@ -2612,7 +2612,7 @@ class CloudTestCase(test.TestCase):
                           no_reboot=True)
 
     @staticmethod
-    def _fake_bdm_get(ctxt, id, use_slave=False):
+    def _fake_bdm_get(ctxt, id, use_subordinate=False):
         blockdms = [{'volume_id': 87654321,
                      'source_type': 'volume',
                      'destination_type': 'volume',

--- a/nova/tests/api/openstack/compute/contrib/test_disk_config.py
+++ b/nova/tests/api/openstack/compute/contrib/test_disk_config.py
@@ -65,7 +65,7 @@ class DiskConfigTestCase(test.TestCase):
         self.stubs.Set(db, 'instance_get', fake_instance_get)
 
         def fake_instance_get_by_uuid(context, uuid,
-                                      columns_to_join=None, use_slave=False):
+                                      columns_to_join=None, use_subordinate=False):
             for instance in FAKE_INSTANCES:
                 if uuid == instance['uuid']:
                     return instance

--- a/nova/tests/api/openstack/compute/contrib/test_instance_actions.py
+++ b/nova/tests/api/openstack/compute/contrib/test_instance_actions.py
@@ -79,7 +79,7 @@ class InstanceActionsPolicyTest(test.NoDBTestCase):
 
         def fake_instance_get_by_uuid(context, instance_id,
                                       columns_to_join=None,
-                                      use_slave=False):
+                                      use_subordinate=False):
             return fake_instance.fake_db_instance(
                 **{'name': 'fake', 'project_id': '%s_unequal' %
                        context.project_id})
@@ -97,7 +97,7 @@ class InstanceActionsPolicyTest(test.NoDBTestCase):
 
         def fake_instance_get_by_uuid(context, instance_id,
                                       columns_to_join=None,
-                                      use_slave=False):
+                                      use_subordinate=False):
             return fake_instance.fake_db_instance(
                 **{'name': 'fake', 'project_id': '%s_unequal' %
                        context.project_id})
@@ -120,7 +120,7 @@ class InstanceActionsTest(test.NoDBTestCase):
                      want_objects=False):
             return {'uuid': instance_uuid}
 
-        def fake_instance_get_by_uuid(context, instance_id, use_slave=False):
+        def fake_instance_get_by_uuid(context, instance_id, use_subordinate=False):
             return {'name': 'fake', 'project_id': context.project_id}
 
         self.stubs.Set(compute_api.API, 'get', fake_get)

--- a/nova/tests/api/openstack/compute/contrib/test_security_groups.py
+++ b/nova/tests/api/openstack/compute/contrib/test_security_groups.py
@@ -82,7 +82,7 @@ def security_group_rule_db(rule, id=None):
 
 
 def return_server(context, server_id,
-                  columns_to_join=None, use_slave=False):
+                  columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'id': int(server_id),
            'power_state': 0x01,
@@ -93,7 +93,7 @@ def return_server(context, server_id,
 
 def return_server_by_uuid(context, server_uuid,
                           columns_to_join=None,
-                          use_slave=False):
+                          use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'id': 1,
            'power_state': 0x01,
@@ -403,7 +403,7 @@ class TestSecurityGroups(test.TestCase):
         expected = {'security_groups': groups}
 
         def return_instance(context, server_id,
-                            columns_to_join=None, use_slave=False):
+                            columns_to_join=None, use_subordinate=False):
             self.assertEqual(server_id, FAKE_UUID1)
             return return_server_by_uuid(context, server_id)
 
@@ -430,7 +430,7 @@ class TestSecurityGroups(test.TestCase):
         expected = {'security_groups': []}
 
         def return_instance(context, server_id,
-                            columns_to_join=None, use_slave=False):
+                            columns_to_join=None, use_subordinate=False):
             self.assertEqual(server_id, FAKE_UUID1)
             return return_server_by_uuid(context, server_id)
         mock_db_get_ins.side_effect = return_instance
@@ -1708,7 +1708,7 @@ class SecurityGroupsOutputXmlTest(SecurityGroupsOutputTest):
             root.set('id')
             root.set('imageRef')
             root.set('flavorRef')
-            return xmlutil.MasterTemplate(root, 1,
+            return xmlutil.MainTemplate(root, 1,
                                           nsmap={None: xmlutil.XMLNS_V11})
 
     def _encode_body(self, body):

--- a/nova/tests/api/openstack/compute/contrib/test_server_start_stop.py
+++ b/nova/tests/api/openstack/compute/contrib/test_server_start_stop.py
@@ -26,7 +26,7 @@ from nova.tests.api.openstack import fakes
 
 
 def fake_instance_get(context, instance_id,
-                      columns_to_join=None, use_slave=False):
+                      columns_to_join=None, use_subordinate=False):
     result = fakes.stub_instance(id=1, uuid=instance_id)
     result['created_at'] = None
     result['deleted_at'] = None

--- a/nova/tests/api/openstack/compute/contrib/test_shelve.py
+++ b/nova/tests/api/openstack/compute/contrib/test_shelve.py
@@ -28,7 +28,7 @@ from nova.tests import fake_instance
 
 
 def fake_instance_get_by_uuid(context, instance_id,
-                              columns_to_join=None, use_slave=False):
+                              columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'name': 'fake', 'project_id': '%s_unequal' % context.project_id})
 

--- a/nova/tests/api/openstack/compute/contrib/test_volumes.py
+++ b/nova/tests/api/openstack/compute/contrib/test_volumes.py
@@ -97,7 +97,7 @@ def fake_compute_volume_snapshot_create(self, context, volume_id,
     pass
 
 
-def fake_bdms_get_all_by_instance(context, instance_uuid, use_slave=False):
+def fake_bdms_get_all_by_instance(context, instance_uuid, use_subordinate=False):
     return [fake_block_device.FakeDbBlockDeviceDict(
             {'id': 1,
              'instance_uuid': instance_uuid,

--- a/nova/tests/api/openstack/compute/plugins/v3/test_instance_actions.py
+++ b/nova/tests/api/openstack/compute/plugins/v3/test_instance_actions.py
@@ -83,7 +83,7 @@ class ServerActionsPolicyTest(test.NoDBTestCase):
         policy.set_rules(rules)
 
         def fake_instance_get_by_uuid(context, instance_id,
-                                      columns_to_join=None, use_slave=False):
+                                      columns_to_join=None, use_subordinate=False):
             return fake_instance.fake_db_instance(
                 **{'name': 'fake', 'project_id': '%s_unequal' %
                        context.project_id})
@@ -100,7 +100,7 @@ class ServerActionsPolicyTest(test.NoDBTestCase):
         policy.set_rules(rules)
 
         def fake_instance_get_by_uuid(context, instance_id,
-                                      columns_to_join=None, use_slave=False):
+                                      columns_to_join=None, use_subordinate=False):
             return fake_instance.fake_db_instance(
                 **{'name': 'fake', 'project_id': '%s_unequal' %
                        context.project_id})
@@ -124,7 +124,7 @@ class ServerActionsTest(test.NoDBTestCase):
             return {'uuid': instance_uuid}
 
         def fake_instance_get_by_uuid(context, instance_id,
-                                      columns_to_join=None, use_slave=False):
+                                      columns_to_join=None, use_subordinate=False):
             return fake_instance.fake_db_instance(
                 **{'name': 'fake', 'project_id': '%s_unequal' %
                        context.project_id})

--- a/nova/tests/api/openstack/compute/plugins/v3/test_server_actions.py
+++ b/nova/tests/api/openstack/compute/plugins/v3/test_server_actions.py
@@ -461,7 +461,7 @@ class ServerActionsControllerTest(test.TestCase):
 
     def test_rebuild_server_not_found(self):
         def server_not_found(self, instance_id,
-                             columns_to_join=None, use_slave=False):
+                             columns_to_join=None, use_subordinate=False):
             raise exception.InstanceNotFound(instance_id=instance_id)
         self.stubs.Set(db, 'instance_get_by_uuid', server_not_found)
 
@@ -870,7 +870,7 @@ class ServerActionsControllerTest(test.TestCase):
         image_service.create(None, original_image)
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': _fake_id('a'),
                          'source_type': 'snapshot',
@@ -948,7 +948,7 @@ class ServerActionsControllerTest(test.TestCase):
         image_service = glance.get_default_image_service()
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': _fake_id('a'),
                          'source_type': 'snapshot',

--- a/nova/tests/api/openstack/compute/plugins/v3/test_server_metadata.py
+++ b/nova/tests/api/openstack/compute/plugins/v3/test_server_metadata.py
@@ -90,7 +90,7 @@ def return_server(context, server_id, columns_to_join=None):
 
 
 def return_server_by_uuid(context, server_uuid,
-                          columns_to_join=None, use_slave=False):
+                          columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'id': 1,
            'uuid': '0cc3346e-9fef-4445-abe6-5d2b2690ec64',
@@ -102,7 +102,7 @@ def return_server_by_uuid(context, server_uuid,
 
 
 def return_server_nonexistent(context, server_id,
-                              columns_to_join=None, use_slave=False):
+                              columns_to_join=None, use_subordinate=False):
     raise exception.InstanceNotFound(instance_id=server_id)
 
 
@@ -576,7 +576,7 @@ class BadStateServerMetaDataTest(BaseTest):
                'vm_state': vm_states.BUILDING})
 
     def _return_server_in_build_by_uuid(self, context, server_uuid,
-                                        columns_to_join=None, use_slave=False):
+                                        columns_to_join=None, use_subordinate=False):
         return fake_instance.fake_db_instance(
             **{'id': 1,
                'uuid': '0cc3346e-9fef-4445-abe6-5d2b2690ec64',

--- a/nova/tests/api/openstack/compute/plugins/v3/test_servers.py
+++ b/nova/tests/api/openstack/compute/plugins/v3/test_servers.py
@@ -112,7 +112,7 @@ def fake_start_stop_invalid_state(self, context, instance):
 
 
 def fake_instance_get_by_uuid_not_found(context, uuid,
-                                        columns_to_join, use_slave=False):
+                                        columns_to_join, use_subordinate=False):
     raise exception.InstanceNotFound(instance_id=uuid)
 
 
@@ -693,7 +693,7 @@ class ServersControllerTest(ControllerTest):
     def test_tenant_id_filter_converts_to_project_id_for_admin(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=None):
             self.assertIsNotNone(filters)
             self.assertEqual(filters['project_id'], 'newfake')
@@ -713,7 +713,7 @@ class ServersControllerTest(ControllerTest):
     def test_tenant_id_filter_no_admin_context(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=None):
             self.assertNotEqual(filters, None)
             self.assertEqual(filters['project_id'], 'fake')
@@ -729,7 +729,7 @@ class ServersControllerTest(ControllerTest):
     def test_tenant_id_filter_implies_all_tenants(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=None):
             self.assertNotEqual(filters, None)
             # The project_id assertion checks that the project_id
@@ -751,7 +751,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_normal(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=None):
             self.assertNotIn('project_id', filters)
             return [fakes.stub_instance(100)]
@@ -768,7 +768,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_one(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=None):
             self.assertNotIn('project_id', filters)
             return [fakes.stub_instance(100)]
@@ -785,7 +785,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_zero(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=None):
             self.assertNotIn('all_tenants', filters)
             return [fakes.stub_instance(100)]
@@ -802,7 +802,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_false(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=None):
             self.assertNotIn('all_tenants', filters)
             return [fakes.stub_instance(100)]
@@ -835,7 +835,7 @@ class ServersControllerTest(ControllerTest):
     def test_admin_restricted_tenant(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=None):
             self.assertIsNotNone(filters)
             self.assertEqual(filters['project_id'], 'fake')
@@ -853,7 +853,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_pass_policy(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=None):
             self.assertIsNotNone(filters)
             self.assertNotIn('project_id', filters)

--- a/nova/tests/api/openstack/compute/plugins/v3/test_shelve.py
+++ b/nova/tests/api/openstack/compute/plugins/v3/test_shelve.py
@@ -28,7 +28,7 @@ from nova.tests import fake_instance
 
 
 def fake_instance_get_by_uuid(context, instance_id,
-                              columns_to_join=None, use_slave=False):
+                              columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'name': 'fake', 'project_id': '%s_unequal' % context.project_id})
 

--- a/nova/tests/api/openstack/compute/test_server_actions.py
+++ b/nova/tests/api/openstack/compute/test_server_actions.py
@@ -626,7 +626,7 @@ class ServerActionsControllerTest(test.TestCase):
 
     def test_rebuild_server_not_found(self):
         def server_not_found(self, instance_id,
-                             columns_to_join=None, use_slave=False):
+                             columns_to_join=None, use_subordinate=False):
             raise exception.InstanceNotFound(instance_id=instance_id)
         self.stubs.Set(db, 'instance_get_by_uuid', server_not_found)
 
@@ -1088,7 +1088,7 @@ class ServerActionsControllerTest(test.TestCase):
         image_service.create(None, original_image)
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': _fake_id('a'),
                          'source_type': 'snapshot',
@@ -1166,7 +1166,7 @@ class ServerActionsControllerTest(test.TestCase):
         image_service = glance.get_default_image_service()
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': _fake_id('a'),
                          'source_type': 'snapshot',

--- a/nova/tests/api/openstack/compute/test_server_metadata.py
+++ b/nova/tests/api/openstack/compute/test_server_metadata.py
@@ -91,7 +91,7 @@ def return_server(context, server_id, columns_to_join=None):
 
 
 def return_server_by_uuid(context, server_uuid,
-                          columns_to_join=None, use_slave=False):
+                          columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'id': 1,
            'uuid': '0cc3346e-9fef-4445-abe6-5d2b2690ec64',
@@ -103,7 +103,7 @@ def return_server_by_uuid(context, server_uuid,
 
 
 def return_server_nonexistent(context, server_id,
-        columns_to_join=None, use_slave=False):
+        columns_to_join=None, use_subordinate=False):
     raise exception.InstanceNotFound(instance_id=server_id)
 
 
@@ -569,7 +569,7 @@ class BadStateServerMetaDataTest(BaseTest):
                'vm_state': vm_states.BUILDING})
 
     def _return_server_in_build_by_uuid(self, context, server_uuid,
-                                        columns_to_join=None, use_slave=False):
+                                        columns_to_join=None, use_subordinate=False):
         return fake_instance.fake_db_instance(
             **{'id': 1,
                'uuid': '0cc3346e-9fef-4445-abe6-5d2b2690ec64',

--- a/nova/tests/api/openstack/compute/test_servers.py
+++ b/nova/tests/api/openstack/compute/test_servers.py
@@ -659,7 +659,7 @@ class ServersControllerTest(ControllerTest):
     def test_tenant_id_filter_converts_to_project_id_for_admin(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertIsNotNone(filters)
             self.assertEqual(filters['project_id'], 'newfake')
             self.assertFalse(filters.get('tenant_id'))
@@ -678,7 +678,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_normal(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertNotIn('project_id', filters)
             return [fakes.stub_instance(100)]
 
@@ -694,7 +694,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_one(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertNotIn('project_id', filters)
             return [fakes.stub_instance(100)]
 
@@ -710,7 +710,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_zero(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertNotIn('all_tenants', filters)
             return [fakes.stub_instance(100)]
 
@@ -726,7 +726,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_false(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertNotIn('all_tenants', filters)
             return [fakes.stub_instance(100)]
 
@@ -757,7 +757,7 @@ class ServersControllerTest(ControllerTest):
     def test_admin_restricted_tenant(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertIsNotNone(filters)
             self.assertEqual(filters['project_id'], 'fake')
             return [fakes.stub_instance(100)]
@@ -774,7 +774,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_pass_policy(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertIsNotNone(filters)
             self.assertNotIn('project_id', filters)
             return [fakes.stub_instance(100)]

--- a/nova/tests/api/openstack/fakes.py
+++ b/nova/tests/api/openstack/fakes.py
@@ -370,7 +370,7 @@ def get_fake_uuid(token=0):
 
 
 def fake_instance_get(**kwargs):
-    def _return_server(context, uuid, columns_to_join=None, use_slave=False):
+    def _return_server(context, uuid, columns_to_join=None, use_subordinate=False):
         return stub_instance(1, **kwargs)
     return _return_server
 
@@ -393,8 +393,8 @@ def fake_instance_get_all_by_filters(num_servers=5, **kwargs):
         if 'columns_to_join' in kwargs:
             kwargs.pop('columns_to_join')
 
-        if 'use_slave' in kwargs:
-            kwargs.pop('use_slave')
+        if 'use_subordinate' in kwargs:
+            kwargs.pop('use_subordinate')
 
         for i in xrange(num_servers):
             uuid = get_fake_uuid(i)
@@ -641,7 +641,7 @@ def stub_snapshot_get_all(self, context):
             stub_snapshot(102, project_id='superduperfake')]
 
 
-def stub_bdm_get_all_by_instance(context, instance_uuid, use_slave=False):
+def stub_bdm_get_all_by_instance(context, instance_uuid, use_subordinate=False):
     return [fake_block_device.FakeDbBlockDeviceDict(
             {'id': 1, 'source_type': 'volume', 'destination_type': 'volume',
             'volume_id': 'volume_id1', 'instance_uuid': instance_uuid}),

--- a/nova/tests/api/openstack/test_xmlutil.py
+++ b/nova/tests/api/openstack/test_xmlutil.py
@@ -392,17 +392,17 @@ class TemplateElementTest(test.NoDBTestCase):
                      attr2=xmlutil.ConstantSelector(2),
                      attr3=xmlutil.ConstantSelector(3))
 
-        # Create a master template element
-        master_elem = xmlutil.TemplateElement('test', attr1=attrs['attr1'])
+        # Create a main template element
+        main_elem = xmlutil.TemplateElement('test', attr1=attrs['attr1'])
 
-        # Create a couple of slave template element
-        slave_elems = [
+        # Create a couple of subordinate template element
+        subordinate_elems = [
             xmlutil.TemplateElement('test', attr2=attrs['attr2']),
             xmlutil.TemplateElement('test', attr3=attrs['attr3']),
             ]
 
         # Try the render
-        elem = master_elem._render(None, None, slave_elems, None)
+        elem = main_elem._render(None, None, subordinate_elems, None)
 
         # Verify the particulars of the render
         self.assertEqual(elem.tag, 'test')
@@ -414,7 +414,7 @@ class TemplateElementTest(test.NoDBTestCase):
         parent = etree.Element('parent')
 
         # Try the render again...
-        elem = master_elem._render(parent, None, slave_elems, dict(a='foo'))
+        elem = main_elem._render(parent, None, subordinate_elems, dict(a='foo'))
 
         # Verify the particulars of the render
         self.assertEqual(len(parent), 1)
@@ -551,47 +551,47 @@ class TemplateTest(test.NoDBTestCase):
         self.assertEqual(len(nsmap), 1)
         self.assertEqual(nsmap['a'], 'foo')
 
-    def test_master_attach(self):
-        # Set up a master template
+    def test_main_attach(self):
+        # Set up a main template
         elem = xmlutil.TemplateElement('test')
-        tmpl = xmlutil.MasterTemplate(elem, 1)
+        tmpl = xmlutil.MainTemplate(elem, 1)
 
-        # Make sure it has a root but no slaves
+        # Make sure it has a root but no subordinates
         self.assertEqual(tmpl.root, elem)
-        self.assertEqual(len(tmpl.slaves), 0)
+        self.assertEqual(len(tmpl.subordinates), 0)
         self.assertTrue(repr(tmpl))
 
-        # Try to attach an invalid slave
+        # Try to attach an invalid subordinate
         bad_elem = xmlutil.TemplateElement('test2')
         self.assertRaises(ValueError, tmpl.attach, bad_elem)
-        self.assertEqual(len(tmpl.slaves), 0)
+        self.assertEqual(len(tmpl.subordinates), 0)
 
-        # Try to attach an invalid and a valid slave
+        # Try to attach an invalid and a valid subordinate
         good_elem = xmlutil.TemplateElement('test')
         self.assertRaises(ValueError, tmpl.attach, good_elem, bad_elem)
-        self.assertEqual(len(tmpl.slaves), 0)
+        self.assertEqual(len(tmpl.subordinates), 0)
 
         # Try to attach an inapplicable template
         class InapplicableTemplate(xmlutil.Template):
-            def apply(self, master):
+            def apply(self, main):
                 return False
         inapp_tmpl = InapplicableTemplate(good_elem)
         tmpl.attach(inapp_tmpl)
-        self.assertEqual(len(tmpl.slaves), 0)
+        self.assertEqual(len(tmpl.subordinates), 0)
 
         # Now try attaching an applicable template
         tmpl.attach(good_elem)
-        self.assertEqual(len(tmpl.slaves), 1)
-        self.assertEqual(tmpl.slaves[0].root, good_elem)
+        self.assertEqual(len(tmpl.subordinates), 1)
+        self.assertEqual(tmpl.subordinates[0].root, good_elem)
 
-    def test_master_copy(self):
-        # Construct a master template
+    def test_main_copy(self):
+        # Construct a main template
         elem = xmlutil.TemplateElement('test')
-        tmpl = xmlutil.MasterTemplate(elem, 1, nsmap=dict(a='foo'))
+        tmpl = xmlutil.MainTemplate(elem, 1, nsmap=dict(a='foo'))
 
-        # Give it a slave
-        slave = xmlutil.TemplateElement('test')
-        tmpl.attach(slave)
+        # Give it a subordinate
+        subordinate = xmlutil.TemplateElement('test')
+        tmpl.attach(subordinate)
 
         # Construct a copy
         copy = tmpl.copy()
@@ -601,43 +601,43 @@ class TemplateTest(test.NoDBTestCase):
         self.assertEqual(tmpl.root, copy.root)
         self.assertEqual(tmpl.version, copy.version)
         self.assertEqual(id(tmpl.nsmap), id(copy.nsmap))
-        self.assertNotEqual(id(tmpl.slaves), id(copy.slaves))
-        self.assertEqual(len(tmpl.slaves), len(copy.slaves))
-        self.assertEqual(tmpl.slaves[0], copy.slaves[0])
+        self.assertNotEqual(id(tmpl.subordinates), id(copy.subordinates))
+        self.assertEqual(len(tmpl.subordinates), len(copy.subordinates))
+        self.assertEqual(tmpl.subordinates[0], copy.subordinates[0])
 
-    def test_slave_apply(self):
-        # Construct a master template
+    def test_subordinate_apply(self):
+        # Construct a main template
         elem = xmlutil.TemplateElement('test')
-        master = xmlutil.MasterTemplate(elem, 3)
+        main = xmlutil.MainTemplate(elem, 3)
 
-        # Construct a slave template with applicable minimum version
-        slave = xmlutil.SlaveTemplate(elem, 2)
-        self.assertEqual(slave.apply(master), True)
-        self.assertTrue(repr(slave))
+        # Construct a subordinate template with applicable minimum version
+        subordinate = xmlutil.SubordinateTemplate(elem, 2)
+        self.assertEqual(subordinate.apply(main), True)
+        self.assertTrue(repr(subordinate))
 
-        # Construct a slave template with equal minimum version
-        slave = xmlutil.SlaveTemplate(elem, 3)
-        self.assertEqual(slave.apply(master), True)
+        # Construct a subordinate template with equal minimum version
+        subordinate = xmlutil.SubordinateTemplate(elem, 3)
+        self.assertEqual(subordinate.apply(main), True)
 
-        # Construct a slave template with inapplicable minimum version
-        slave = xmlutil.SlaveTemplate(elem, 4)
-        self.assertEqual(slave.apply(master), False)
+        # Construct a subordinate template with inapplicable minimum version
+        subordinate = xmlutil.SubordinateTemplate(elem, 4)
+        self.assertEqual(subordinate.apply(main), False)
 
-        # Construct a slave template with applicable version range
-        slave = xmlutil.SlaveTemplate(elem, 2, 4)
-        self.assertEqual(slave.apply(master), True)
+        # Construct a subordinate template with applicable version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 2, 4)
+        self.assertEqual(subordinate.apply(main), True)
 
-        # Construct a slave template with low version range
-        slave = xmlutil.SlaveTemplate(elem, 1, 2)
-        self.assertEqual(slave.apply(master), False)
+        # Construct a subordinate template with low version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 1, 2)
+        self.assertEqual(subordinate.apply(main), False)
 
-        # Construct a slave template with high version range
-        slave = xmlutil.SlaveTemplate(elem, 4, 5)
-        self.assertEqual(slave.apply(master), False)
+        # Construct a subordinate template with high version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 4, 5)
+        self.assertEqual(subordinate.apply(main), False)
 
-        # Construct a slave template with matching version range
-        slave = xmlutil.SlaveTemplate(elem, 3, 3)
-        self.assertEqual(slave.apply(master), True)
+        # Construct a subordinate template with matching version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 3, 3)
+        self.assertEqual(subordinate.apply(main), True)
 
     def test__serialize(self):
         # Our test object to serialize
@@ -658,7 +658,7 @@ class TemplateTest(test.NoDBTestCase):
                 },
             }
 
-        # Set up our master template
+        # Set up our main template
         root = xmlutil.TemplateElement('test', selector='test',
                                        name='name')
         value = xmlutil.SubTemplateElement(root, 'value', selector='values')
@@ -666,22 +666,22 @@ class TemplateTest(test.NoDBTestCase):
         attrs = xmlutil.SubTemplateElement(root, 'attrs', selector='attrs')
         xmlutil.SubTemplateElement(attrs, 'attr', selector=xmlutil.get_items,
                                    key=0, value=1)
-        master = xmlutil.MasterTemplate(root, 1, nsmap=dict(f='foo'))
+        main = xmlutil.MainTemplate(root, 1, nsmap=dict(f='foo'))
 
-        # Set up our slave template
-        root_slave = xmlutil.TemplateElement('test', selector='test')
-        image = xmlutil.SubTemplateElement(root_slave, 'image',
+        # Set up our subordinate template
+        root_subordinate = xmlutil.TemplateElement('test', selector='test')
+        image = xmlutil.SubTemplateElement(root_subordinate, 'image',
                                            selector='image', id='id')
         image.text = xmlutil.Selector('name')
-        slave = xmlutil.SlaveTemplate(root_slave, 1, nsmap=dict(b='bar'))
+        subordinate = xmlutil.SubordinateTemplate(root_subordinate, 1, nsmap=dict(b='bar'))
 
-        # Attach the slave to the master...
-        master.attach(slave)
+        # Attach the subordinate to the main...
+        main.attach(subordinate)
 
         # Try serializing our object
-        siblings = master._siblings()
-        nsmap = master._nsmap()
-        result = master._serialize(None, obj, siblings, nsmap)
+        siblings = main._siblings()
+        nsmap = main._nsmap()
+        result = main._serialize(None, obj, siblings, nsmap)
 
         # Now we get to manually walk the element tree...
         self.assertEqual(result.tag, 'test')
@@ -713,14 +713,14 @@ class TemplateTest(test.NoDBTestCase):
         expected_xml = (("<?xml version='1.0' encoding='UTF-8'?>\n"
                     '<extra_specs><foo:bar xmlns:foo="foo">999</foo:bar>'
                     '</extra_specs>'))
-        # Set up our master template
+        # Set up our main template
         root = xmlutil.TemplateElement('extra_specs', selector='extra_specs',
                                        colon_ns=True)
         value = xmlutil.SubTemplateElement(root, 'foo:bar', selector='foo:bar',
                                            colon_ns=True)
         value.text = xmlutil.Selector()
-        master = xmlutil.MasterTemplate(root, 1)
-        result = master.serialize(obj)
+        main = xmlutil.MainTemplate(root, 1)
+        result = main.serialize(obj)
         self.assertEqual(expected_xml, result)
 
     def test__serialize_with_empty_datum_selector(self):
@@ -734,76 +734,76 @@ class TemplateTest(test.NoDBTestCase):
 
         root = xmlutil.TemplateElement('test', selector='test',
                                        name='name')
-        master = xmlutil.MasterTemplate(root, 1)
-        root_slave = xmlutil.TemplateElement('test', selector='test')
-        image = xmlutil.SubTemplateElement(root_slave, 'image',
+        main = xmlutil.MainTemplate(root, 1)
+        root_subordinate = xmlutil.TemplateElement('test', selector='test')
+        image = xmlutil.SubTemplateElement(root_subordinate, 'image',
                                            selector='image')
         image.set('id')
         xmlutil.make_links(image, 'links')
-        slave = xmlutil.SlaveTemplate(root_slave, 1)
-        master.attach(slave)
+        subordinate = xmlutil.SubordinateTemplate(root_subordinate, 1)
+        main.attach(subordinate)
 
-        siblings = master._siblings()
-        result = master._serialize(None, obj, siblings)
+        siblings = main._siblings()
+        result = main._serialize(None, obj, siblings)
         self.assertEqual(result.tag, 'test')
         self.assertEqual(result[0].tag, 'image')
         self.assertEqual(result[0].get('id'), str(obj['test']['image']))
 
 
-class MasterTemplateBuilder(xmlutil.TemplateBuilder):
+class MainTemplateBuilder(xmlutil.TemplateBuilder):
     def construct(self):
         elem = xmlutil.TemplateElement('test')
-        return xmlutil.MasterTemplate(elem, 1)
+        return xmlutil.MainTemplate(elem, 1)
 
 
-class SlaveTemplateBuilder(xmlutil.TemplateBuilder):
+class SubordinateTemplateBuilder(xmlutil.TemplateBuilder):
     def construct(self):
         elem = xmlutil.TemplateElement('test')
-        return xmlutil.SlaveTemplate(elem, 1)
+        return xmlutil.SubordinateTemplate(elem, 1)
 
 
 class TemplateBuilderTest(test.NoDBTestCase):
-    def test_master_template_builder(self):
+    def test_main_template_builder(self):
         # Make sure the template hasn't been built yet
-        self.assertIsNone(MasterTemplateBuilder._tmpl)
+        self.assertIsNone(MainTemplateBuilder._tmpl)
 
         # Now, construct the template
-        tmpl1 = MasterTemplateBuilder()
+        tmpl1 = MainTemplateBuilder()
 
         # Make sure that there is a template cached...
-        self.assertIsNotNone(MasterTemplateBuilder._tmpl)
+        self.assertIsNotNone(MainTemplateBuilder._tmpl)
 
         # Make sure it wasn't what was returned...
-        self.assertNotEqual(MasterTemplateBuilder._tmpl, tmpl1)
+        self.assertNotEqual(MainTemplateBuilder._tmpl, tmpl1)
 
         # Make sure it doesn't get rebuilt
-        cached = MasterTemplateBuilder._tmpl
-        tmpl2 = MasterTemplateBuilder()
-        self.assertEqual(MasterTemplateBuilder._tmpl, cached)
+        cached = MainTemplateBuilder._tmpl
+        tmpl2 = MainTemplateBuilder()
+        self.assertEqual(MainTemplateBuilder._tmpl, cached)
 
         # Make sure we're always getting fresh copies
         self.assertNotEqual(tmpl1, tmpl2)
 
         # Make sure we can override the copying behavior
-        tmpl3 = MasterTemplateBuilder(False)
-        self.assertEqual(MasterTemplateBuilder._tmpl, tmpl3)
+        tmpl3 = MainTemplateBuilder(False)
+        self.assertEqual(MainTemplateBuilder._tmpl, tmpl3)
 
-    def test_slave_template_builder(self):
+    def test_subordinate_template_builder(self):
         # Make sure the template hasn't been built yet
-        self.assertIsNone(SlaveTemplateBuilder._tmpl)
+        self.assertIsNone(SubordinateTemplateBuilder._tmpl)
 
         # Now, construct the template
-        tmpl1 = SlaveTemplateBuilder()
+        tmpl1 = SubordinateTemplateBuilder()
 
         # Make sure there is a template cached...
-        self.assertIsNotNone(SlaveTemplateBuilder._tmpl)
+        self.assertIsNotNone(SubordinateTemplateBuilder._tmpl)
 
         # Make sure it was what was returned...
-        self.assertEqual(SlaveTemplateBuilder._tmpl, tmpl1)
+        self.assertEqual(SubordinateTemplateBuilder._tmpl, tmpl1)
 
         # Make sure it doesn't get rebuilt
-        tmpl2 = SlaveTemplateBuilder()
-        self.assertEqual(SlaveTemplateBuilder._tmpl, tmpl1)
+        tmpl2 = SubordinateTemplateBuilder()
+        self.assertEqual(SubordinateTemplateBuilder._tmpl, tmpl1)
 
         # Make sure we're always getting the cached copy
         self.assertEqual(tmpl1, tmpl2)
@@ -829,7 +829,7 @@ class MiscellaneousXMLUtilTests(test.NoDBTestCase):
         expected_xml = ("<?xml version='1.0' encoding='UTF-8'?>\n"
                         '<wrapper><a>foo</a><b>bar</b></wrapper>')
         root = xmlutil.make_flat_dict('wrapper')
-        tmpl = xmlutil.MasterTemplate(root, 1)
+        tmpl = xmlutil.MainTemplate(root, 1)
         result = tmpl.serialize(dict(wrapper=dict(a='foo', b='bar')))
         self.assertEqual(result, expected_xml)
 
@@ -837,7 +837,7 @@ class MiscellaneousXMLUtilTests(test.NoDBTestCase):
 '<ns0:wrapper xmlns:ns0="ns"><ns0:a>foo</ns0:a><ns0:b>bar</ns0:b>'
 "</ns0:wrapper>")
         root = xmlutil.make_flat_dict('wrapper', ns='ns')
-        tmpl = xmlutil.MasterTemplate(root, 1)
+        tmpl = xmlutil.MainTemplate(root, 1)
         result = tmpl.serialize(dict(wrapper=dict(a='foo', b='bar')))
         self.assertEqual(result, expected_xml)
 
@@ -847,10 +847,10 @@ class MiscellaneousXMLUtilTests(test.NoDBTestCase):
         expected_xml = (("<?xml version='1.0' encoding='UTF-8'?>\n"
                     '<extra_specs><foo:bar xmlns:foo="foo">999</foo:bar>'
                     '</extra_specs>'))
-        # Set up our master template
+        # Set up our main template
         root = xmlutil.make_flat_dict('extra_specs', colon_ns=True)
-        master = xmlutil.MasterTemplate(root, 1)
-        result = master.serialize(obj)
+        main = xmlutil.MainTemplate(root, 1)
+        result = main.serialize(obj)
         self.assertEqual(expected_xml, result)
 
     def test_make_flat_dict_with_parent(self):
@@ -867,8 +867,8 @@ class MiscellaneousXMLUtilTests(test.NoDBTestCase):
         root.set('id')
         extra = xmlutil.make_flat_dict('extra_info', root=root)
         root.append(extra)
-        master = xmlutil.MasterTemplate(root, 1)
-        result = master.serialize(obj)
+        main = xmlutil.MainTemplate(root, 1)
+        result = main.serialize(obj)
         self.assertEqual(expected_xml, result)
 
     def test_make_flat_dict_with_dicts(self):
@@ -885,8 +885,8 @@ class MiscellaneousXMLUtilTests(test.NoDBTestCase):
                                       ignore_sub_dicts=True)
         extra = xmlutil.make_flat_dict('extra_info', selector='extra_info')
         root.append(extra)
-        master = xmlutil.MasterTemplate(root, 1)
-        result = master.serialize(obj)
+        main = xmlutil.MainTemplate(root, 1)
+        result = main.serialize(obj)
         self.assertEqual(expected_xml, result)
 
     def test_safe_parse_xml(self):

--- a/nova/tests/compute/test_compute.py
+++ b/nova/tests/compute/test_compute.py
@@ -640,7 +640,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         time.time().AndReturn(20)
         time.time().AndReturn(21)
         objects.InstanceList.get_by_host(ctxt, 'fake-mini',
-                                         use_slave=True).AndReturn([])
+                                         use_subordinate=True).AndReturn([])
         self.compute.driver.get_all_bw_counters([]).AndRaise(
             NotImplementedError)
         self.mox.ReplayAll()
@@ -5923,9 +5923,9 @@ class ComputeTestCase(BaseTestCase):
         self.compute._shutdown_instance(ctxt, inst1, bdms, notify=False).\
                                         AndRaise(test.TestingException)
         objects.BlockDeviceMappingList.get_by_instance_uuid(ctxt,
-                inst1.uuid, use_slave=True).AndReturn(bdms)
+                inst1.uuid, use_subordinate=True).AndReturn(bdms)
         objects.BlockDeviceMappingList.get_by_instance_uuid(ctxt,
-                inst2.uuid, use_slave=True).AndReturn(bdms)
+                inst2.uuid, use_subordinate=True).AndReturn(bdms)
         self.compute._shutdown_instance(ctxt, inst2, bdms, notify=False).\
                                         AndReturn(None)
 
@@ -6030,7 +6030,7 @@ class ComputeTestCase(BaseTestCase):
         db.instance_get_by_uuid(self.context, fake_inst['uuid'],
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.compute.network_api.get_instance_nw_info(self.context,
                 mox.IsA(objects.Instance)).AndReturn(fake_nw_info)
@@ -6061,13 +6061,13 @@ class ComputeTestCase(BaseTestCase):
                 'get_nw_info': 0, 'expected_instance': None}
 
         def fake_instance_get_all_by_host(context, host,
-                                          columns_to_join, use_slave=False):
+                                          columns_to_join, use_subordinate=False):
             call_info['get_all_by_host'] += 1
             self.assertEqual([], columns_to_join)
             return instances[:]
 
         def fake_instance_get_by_uuid(context, instance_uuid,
-                                      columns_to_join, use_slave=False):
+                                      columns_to_join, use_subordinate=False):
             if instance_uuid not in instance_map:
                 raise exception.InstanceNotFound(instance_id=instance_uuid)
             call_info['get_by_uuid'] += 1
@@ -6076,7 +6076,7 @@ class ComputeTestCase(BaseTestCase):
             return instance_map[instance_uuid]
 
         # NOTE(comstud): Override the stub in setUp()
-        def fake_get_instance_nw_info(context, instance, use_slave=False):
+        def fake_get_instance_nw_info(context, instance, use_subordinate=False):
             # Note that this exception gets caught in compute/manager
             # and is ignored.  However, the below increment of
             # 'get_nw_info' won't happen, and you'll get an assert
@@ -6156,7 +6156,7 @@ class ComputeTestCase(BaseTestCase):
 
         def fake_instance_get_all_by_filters(context, filters,
                                              expected_attrs=None,
-                                             use_slave=False):
+                                             use_subordinate=False):
             self.assertEqual(["system_metadata"], expected_attrs)
             return instances
 
@@ -6213,7 +6213,7 @@ class ComputeTestCase(BaseTestCase):
             migrations.append(fake_mig)
 
         def fake_instance_get_by_uuid(context, instance_uuid,
-                columns_to_join=None, use_slave=False):
+                columns_to_join=None, use_subordinate=False):
             self.assertIn('metadata', columns_to_join)
             self.assertIn('system_metadata', columns_to_join)
             # raise InstanceNotFound exception for uuid 'noexist'
@@ -6224,7 +6224,7 @@ class ComputeTestCase(BaseTestCase):
                     return instance
 
         def fake_migration_get_unconfirmed_by_dest_compute(context,
-                resize_confirm_window, dest_compute, use_slave=False):
+                resize_confirm_window, dest_compute, use_subordinate=False):
             self.assertEqual(dest_compute, CONF.host)
             return migrations
 
@@ -6321,7 +6321,7 @@ class ComputeTestCase(BaseTestCase):
                                             sort_dir,
                                             marker=None,
                                             columns_to_join=[],
-                                            use_slave=True,
+                                            use_subordinate=True,
                                             limit=None)
             self.assertThat(conductor_instance_update.mock_calls,
                             testtools_matchers.HasLength(len(old_instances)))
@@ -6677,7 +6677,7 @@ class ComputeTestCase(BaseTestCase):
         objects.InstanceList.get_by_filters(
             ctxt, mox.IgnoreArg(),
             expected_attrs=instance_obj.INSTANCE_DEFAULT_FIELDS,
-            use_slave=True
+            use_subordinate=True
             ).AndReturn(instances)
 
         # The first instance delete fails.
@@ -6718,12 +6718,12 @@ class ComputeTestCase(BaseTestCase):
             {'state': power_state.RUNNING})
         self.compute._sync_instance_power_state(ctxt, mox.IgnoreArg(),
                                                 power_state.RUNNING,
-                                                use_slave=True)
+                                                use_subordinate=True)
         self.compute.driver.get_info(mox.IgnoreArg()).AndReturn(
             {'state': power_state.SHUTDOWN})
         self.compute._sync_instance_power_state(ctxt, mox.IgnoreArg(),
                                                 power_state.SHUTDOWN,
-                                                use_slave=True)
+                                                use_subordinate=True)
         self.mox.ReplayAll()
         self.compute._sync_power_states(ctxt)
 
@@ -7649,7 +7649,7 @@ class ComputeAPITestCase(BaseTestCase):
                 instance_obj.INSTANCE_DEFAULT_FIELDS + ['fault']))
 
         def fake_db_get(_context, _instance_uuid,
-                        columns_to_join=None, use_slave=False):
+                        columns_to_join=None, use_subordinate=False):
             return exp_instance
 
         self.stubs.Set(db, 'instance_get_by_uuid', fake_db_get)
@@ -7670,7 +7670,7 @@ class ComputeAPITestCase(BaseTestCase):
                 instance_obj.INSTANCE_DEFAULT_FIELDS + ['fault']))
 
         def fake_db_get(context, instance_uuid,
-                        columns_to_join=None, use_slave=False):
+                        columns_to_join=None, use_subordinate=False):
             return exp_instance
 
         self.stubs.Set(db, 'instance_get_by_uuid', fake_db_get)
@@ -10034,7 +10034,7 @@ class ComputeAggrTestCase(BaseTestCase):
                        fake_driver_add_to_aggregate)
 
         self.compute.add_aggregate_host(self.context, host="host",
-                aggregate=jsonutils.to_primitive(self.aggr), slave_info=None)
+                aggregate=jsonutils.to_primitive(self.aggr), subordinate_info=None)
         self.assertTrue(fake_driver_add_to_aggregate.called)
 
     def test_remove_aggregate_host(self):
@@ -10048,36 +10048,36 @@ class ComputeAggrTestCase(BaseTestCase):
 
         self.compute.remove_aggregate_host(self.context,
                 aggregate=jsonutils.to_primitive(self.aggr), host="host",
-                slave_info=None)
+                subordinate_info=None)
         self.assertTrue(fake_driver_remove_from_aggregate.called)
 
-    def test_add_aggregate_host_passes_slave_info_to_driver(self):
+    def test_add_aggregate_host_passes_subordinate_info_to_driver(self):
         def driver_add_to_aggregate(context, aggregate, host, **kwargs):
             self.assertEqual(self.context, context)
             self.assertEqual(aggregate['id'], self.aggr['id'])
             self.assertEqual(host, "the_host")
-            self.assertEqual("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEqual("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stubs.Set(self.compute.driver, "add_to_aggregate",
                        driver_add_to_aggregate)
 
         self.compute.add_aggregate_host(self.context, host="the_host",
-                slave_info="SLAVE_INFO",
+                subordinate_info="SLAVE_INFO",
                 aggregate=jsonutils.to_primitive(self.aggr))
 
-    def test_remove_from_aggregate_passes_slave_info_to_driver(self):
+    def test_remove_from_aggregate_passes_subordinate_info_to_driver(self):
         def driver_remove_from_aggregate(context, aggregate, host, **kwargs):
             self.assertEqual(self.context, context)
             self.assertEqual(aggregate['id'], self.aggr['id'])
             self.assertEqual(host, "the_host")
-            self.assertEqual("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEqual("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stubs.Set(self.compute.driver, "remove_from_aggregate",
                        driver_remove_from_aggregate)
 
         self.compute.remove_aggregate_host(self.context,
                 aggregate=jsonutils.to_primitive(self.aggr), host="the_host",
-                slave_info="SLAVE_INFO")
+                subordinate_info="SLAVE_INFO")
 
 
 class ComputePolicyTestCase(BaseTestCase):

--- a/nova/tests/compute/test_compute_api.py
+++ b/nova/tests/compute/test_compute_api.py
@@ -769,7 +769,7 @@ class _ComputeAPIUnitTestMixIn(object):
 
         db.block_device_mapping_get_all_by_instance(self.context,
                                                  inst.uuid,
-                                                 use_slave=False).AndReturn([])
+                                                 use_subordinate=False).AndReturn([])
         inst.save()
         self.compute_api._create_reservations(self.context,
                                               inst, inst.task_state,
@@ -872,7 +872,7 @@ class _ComputeAPIUnitTestMixIn(object):
         timeutils.set_time_override(delete_time)
 
         db.block_device_mapping_get_all_by_instance(
-            self.context, inst.uuid, use_slave=False).AndReturn([])
+            self.context, inst.uuid, use_subordinate=False).AndReturn([])
         inst.save().AndRaise(test.TestingException)
 
         self.mox.ReplayAll()
@@ -1660,7 +1660,7 @@ class _ComputeAPIUnitTestMixIn(object):
             'is_public': False
         }
 
-        def fake_get_all_by_instance(context, instance, use_slave=False):
+        def fake_get_all_by_instance(context, instance, use_subordinate=False):
             return copy.deepcopy(instance_bdms)
 
         def fake_image_create(context, image_meta, data=None):

--- a/nova/tests/compute/test_compute_mgr.py
+++ b/nova/tests/compute/test_compute_mgr.py
@@ -214,7 +214,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             context.get_admin_context().AndReturn(fake_context)
             db.instance_get_all_by_host(
                     fake_context, our_host, columns_to_join=['info_cache'],
-                    use_slave=False
+                    use_subordinate=False
                     ).AndReturn(startup_instances)
             if defer_iptables_apply:
                 self.compute.driver.filter_defer_apply_on()
@@ -296,7 +296,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
         context.get_admin_context().AndReturn(fake_context)
         db.instance_get_all_by_host(fake_context, our_host,
                                     columns_to_join=['info_cache'],
-                                    use_slave=False
+                                    use_subordinate=False
                                     ).AndReturn([])
         self.compute.init_virt_events()
 
@@ -726,7 +726,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                           inst in driver_instances]},
                 'created_at', 'desc', columns_to_join=None,
                 limit=None, marker=None,
-                use_slave=True).AndReturn(
+                use_subordinate=True).AndReturn(
                         driver_instances)
 
         self.mox.ReplayAll()
@@ -767,7 +767,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                 fake_context, filters,
                 'created_at', 'desc', columns_to_join=None,
                 limit=None, marker=None,
-                use_slave=True).AndReturn(all_instances)
+                use_subordinate=True).AndReturn(all_instances)
 
         self.mox.ReplayAll()
 
@@ -815,7 +815,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
     def test_sync_instance_power_state_match(self):
         instance = self._get_sync_instance(power_state.RUNNING,
                                            vm_states.ACTIVE)
-        instance.refresh(use_slave=False)
+        instance.refresh(use_subordinate=False)
         self.mox.ReplayAll()
         self.compute._sync_instance_power_state(self.context, instance,
                                                 power_state.RUNNING)
@@ -823,7 +823,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
     def test_sync_instance_power_state_running_stopped(self):
         instance = self._get_sync_instance(power_state.RUNNING,
                                            vm_states.ACTIVE)
-        instance.refresh(use_slave=False)
+        instance.refresh(use_subordinate=False)
         instance.save()
         self.mox.ReplayAll()
         self.compute._sync_instance_power_state(self.context, instance,
@@ -834,7 +834,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                            stop=True, force=False, shutdown_terminate=False):
         instance = self._get_sync_instance(
             power_state, vm_state, shutdown_terminate=shutdown_terminate)
-        instance.refresh(use_slave=False)
+        instance.refresh(use_subordinate=False)
         instance.save()
         self.mox.StubOutWithMock(self.compute.compute_api, 'stop')
         self.mox.StubOutWithMock(self.compute.compute_api, 'delete')
@@ -905,7 +905,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             mock_sync_power_state.assert_called_once_with(self.context,
                                                           db_instance,
                                                           power_state.NOSTATE,
-                                                          use_slave=True)
+                                                          use_subordinate=True)
 
     def test_run_pending_deletes(self):
         self.flags(instance_delete_interval=10)

--- a/nova/tests/compute/test_compute_utils.py
+++ b/nova/tests/compute/test_compute_utils.py
@@ -76,7 +76,7 @@ class ComputeValidateDeviceTestCase(test.TestCase):
         self.data = []
 
         self.stubs.Set(db, 'block_device_mapping_get_all_by_instance',
-                       lambda context, instance, use_slave=False: self.data)
+                       lambda context, instance, use_subordinate=False: self.data)
 
     def _update_flavor(self, flavor_info):
         self.flavor = {

--- a/nova/tests/compute/test_compute_xen.py
+++ b/nova/tests/compute/test_compute_xen.py
@@ -52,7 +52,7 @@ class ComputeXenTestCase(stubs.XenAPITestBaseNoDB):
         self.mox.StubOutWithMock(self.compute, '_sync_instance_power_state')
 
         objects.InstanceList.get_by_host(ctxt,
-                self.compute.host, use_slave=True).AndReturn(instance_list)
+                self.compute.host, use_subordinate=True).AndReturn(instance_list)
         self.compute.driver.get_num_instances().AndReturn(1)
         vm_utils.lookup(self.compute.driver._session, instance['name'],
                 False).AndReturn(None)

--- a/nova/tests/compute/test_rpcapi.py
+++ b/nova/tests/compute/test_rpcapi.py
@@ -105,13 +105,13 @@ class ComputeRpcAPITestCase(test.TestCase):
     def test_add_aggregate_host(self):
         self._test_compute_api('add_aggregate_host', 'cast',
                 aggregate={'id': 'fake_id'}, host_param='host', host='host',
-                slave_info={})
+                subordinate_info={})
 
         # NOTE(russellb) Havana compat
         self.flags(compute='havana', group='upgrade_levels')
         self._test_compute_api('add_aggregate_host', 'cast',
                 aggregate={'id': 'fake_id'}, host_param='host', host='host',
-                slave_info={}, version='2.14')
+                subordinate_info={}, version='2.14')
 
     def test_add_fixed_ip_to_instance(self):
         self._test_compute_api('add_fixed_ip_to_instance', 'cast',
@@ -558,13 +558,13 @@ class ComputeRpcAPITestCase(test.TestCase):
     def test_remove_aggregate_host(self):
         self._test_compute_api('remove_aggregate_host', 'cast',
                 aggregate={'id': 'fake_id'}, host_param='host', host='host',
-                slave_info={})
+                subordinate_info={})
 
         # NOTE(russellb) Havana compat
         self.flags(compute='havana', group='upgrade_levels')
         self._test_compute_api('remove_aggregate_host', 'cast',
                 aggregate={'id': 'fake_id'}, host_param='host', host='host',
-                slave_info={}, version='2.15')
+                subordinate_info={}, version='2.15')
 
     def test_remove_fixed_ip_from_instance(self):
         self._test_compute_api('remove_fixed_ip_from_instance', 'cast',

--- a/nova/tests/conductor/test_conductor.py
+++ b/nova/tests/conductor/test_conductor.py
@@ -408,23 +408,23 @@ class ConductorTestCase(_BaseTestCase, test.TestCase):
         self.mox.StubOutWithMock(db, 'instance_get_all_by_filters')
         db.instance_get_all_by_filters(self.context, filters,
                                        'fake-key', 'fake-sort',
-                                       columns_to_join=None, use_slave=False)
+                                       columns_to_join=None, use_subordinate=False)
         self.mox.ReplayAll()
         self.conductor.instance_get_all_by_filters(self.context, filters,
                                                    'fake-key', 'fake-sort',
                                                    None, False)
 
-    def test_instance_get_all_by_filters_use_slave(self):
+    def test_instance_get_all_by_filters_use_subordinate(self):
         filters = {'foo': 'bar'}
         self.mox.StubOutWithMock(db, 'instance_get_all_by_filters')
         db.instance_get_all_by_filters(self.context, filters,
                                        'fake-key', 'fake-sort',
-                                       columns_to_join=None, use_slave=True)
+                                       columns_to_join=None, use_subordinate=True)
         self.mox.ReplayAll()
         self.conductor.instance_get_all_by_filters(self.context, filters,
                                                    'fake-key', 'fake-sort',
                                                    columns_to_join=None,
-                                                   use_slave=True)
+                                                   use_subordinate=True)
 
     def test_instance_get_all_by_host(self):
         self.mox.StubOutWithMock(db, 'instance_get_all_by_host')
@@ -1239,10 +1239,10 @@ class _BaseTaskTestCase(object):
                          {'host': 'host2', 'nodename': 'node2', 'limits': []}])
         db.instance_get_by_uuid(self.context, instances[0].uuid,
                 columns_to_join=['system_metadata'],
-                use_slave=False).AndReturn(
+                use_subordinate=False).AndReturn(
                         jsonutils.to_primitive(instances[0]))
         db.block_device_mapping_get_all_by_instance(self.context,
-                instances[0].uuid, use_slave=False).AndReturn([])
+                instances[0].uuid, use_subordinate=False).AndReturn([])
         self.conductor_manager.compute_rpcapi.build_and_run_instance(
                 self.context,
                 instance=mox.IgnoreArg(),
@@ -1265,10 +1265,10 @@ class _BaseTaskTestCase(object):
                 node='node1', limits=[])
         db.instance_get_by_uuid(self.context, instances[1].uuid,
                 columns_to_join=['system_metadata'],
-                use_slave=False).AndReturn(
+                use_subordinate=False).AndReturn(
                         jsonutils.to_primitive(instances[1]))
         db.block_device_mapping_get_all_by_instance(self.context,
-                instances[1].uuid, use_slave=False).AndReturn([])
+                instances[1].uuid, use_subordinate=False).AndReturn([])
         self.conductor_manager.compute_rpcapi.build_and_run_instance(
                 self.context,
                 instance=mox.IgnoreArg(),

--- a/nova/tests/db/test_db_api.py
+++ b/nova/tests/db/test_db_api.py
@@ -1224,8 +1224,8 @@ class SecurityGroupTestCase(test.TestCase, ModelsObjectComparatorMixin):
 
         session = get_session()
         self.mox.StubOutWithMock(sqlalchemy_api, 'get_session')
-        sqlalchemy_api.get_session(use_slave=False).AndReturn(session)
-        sqlalchemy_api.get_session(use_slave=False).AndReturn(session)
+        sqlalchemy_api.get_session(use_subordinate=False).AndReturn(session)
+        sqlalchemy_api.get_session(use_subordinate=False).AndReturn(session)
         self.mox.ReplayAll()
 
         security_group = db.security_group_get(self.ctxt, sid,

--- a/nova/tests/integrated/test_api_samples.py
+++ b/nova/tests/integrated/test_api_samples.py
@@ -3987,7 +3987,7 @@ class VolumeAttachmentsSampleBase(ServersSampleBase):
     def _stub_db_bdms_get_all_by_instance(self, server_id):
 
         def fake_bdms_get_all_by_instance(context, instance_uuid,
-                                          use_slave=False):
+                                          use_subordinate=False):
             bdms = [
                 fake_block_device.FakeDbBlockDeviceDict(
                 {'id': 1, 'volume_id': 'a26887c6-c47b-4654-abb5-dfadf7d3f803',

--- a/nova/tests/integrated/v3/test_extended_volumes.py
+++ b/nova/tests/integrated/v3/test_extended_volumes.py
@@ -31,7 +31,7 @@ class ExtendedVolumesSampleJsonTests(test_servers.ServersSampleBase):
     def _stub_compute_api_get_instance_bdms(self, server_id):
 
         def fake_bdms_get_all_by_instance(context, instance_uuid,
-                                          use_slave=False):
+                                          use_subordinate=False):
             bdms = [
                 fake_block_device.FakeDbBlockDeviceDict(
                 {'id': 1, 'volume_id': 'a26887c6-c47b-4654-abb5-dfadf7d3f803',

--- a/nova/tests/network/test_api.py
+++ b/nova/tests/network/test_api.py
@@ -115,7 +115,7 @@ class ApiTestCase(test.TestCase):
         self.assertEqual(123, vifs[0].network_id)
         self.assertEqual(str(mock.sentinel.network_uuid), vifs[0].net_uuid)
         mock_get_by_instance.assert_called_once_with(
-            self.context, str(mock.sentinel.inst_uuid), use_slave=False)
+            self.context, str(mock.sentinel.inst_uuid), use_subordinate=False)
         mock_get_by_id.assert_called_once_with(self.context, 123,
                                                project_only='allow_none')
 
@@ -174,7 +174,7 @@ class ApiTestCase(test.TestCase):
 
         def fake_instance_get_by_uuid(context, instance_uuid,
                                       columns_to_join=None,
-                                      use_slave=None):
+                                      use_subordinate=None):
             return fake_instance.fake_db_instance(uuid=instance_uuid)
 
         self.stubs.Set(self.network_api.db, 'instance_get_by_uuid',

--- a/nova/tests/network/test_linux_net.py
+++ b/nova/tests/network/test_linux_net.py
@@ -287,7 +287,7 @@ class LinuxNetworkTestCase(test.NoDBTestCase):
         self.context = context.RequestContext('testuser', 'testproject',
                                               is_admin=True)
 
-        def get_vifs(_context, instance_uuid, use_slave):
+        def get_vifs(_context, instance_uuid, use_subordinate):
             return [vif for vif in vifs if vif['instance_uuid'] ==
                         instance_uuid]
 

--- a/nova/tests/network/test_manager.py
+++ b/nova/tests/network/test_manager.py
@@ -423,7 +423,7 @@ class FlatNetworkTestCase(test.TestCase):
 
         inst = fake_inst(display_name=HOST, uuid=FAKEUUID)
         db.instance_get_by_uuid(self.context,
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(inst)
@@ -476,7 +476,7 @@ class FlatNetworkTestCase(test.TestCase):
 
         inst = fake_inst(display_name=HOST, uuid=FAKEUUID)
         db.instance_get_by_uuid(self.context,
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(inst)
@@ -573,7 +573,7 @@ class FlatNetworkTestCase(test.TestCase):
 
         inst = fake_inst(display_name=HOST, uuid=FAKEUUID)
         db.instance_get_by_uuid(self.context,
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(inst)
@@ -817,7 +817,7 @@ class VlanNetworkTestCase(test.TestCase):
         db.virtual_interface_get_by_instance_and_network(mox.IgnoreArg(),
                 mox.IgnoreArg(), mox.IgnoreArg()).AndReturn(vifs[0])
         db.instance_get_by_uuid(mox.IgnoreArg(),
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(fake_inst(display_name=HOST,
@@ -865,7 +865,7 @@ class VlanNetworkTestCase(test.TestCase):
         db.virtual_interface_get_by_instance_and_network(mox.IgnoreArg(),
                 mox.IgnoreArg(), mox.IgnoreArg()).AndReturn(vifs[0])
         db.instance_get_by_uuid(mox.IgnoreArg(),
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(fake_inst(display_name=HOST,
@@ -1475,7 +1475,7 @@ class VlanNetworkTestCase(test.TestCase):
                        ).AndReturn(dict(test_network.fake_network,
                                         **networks[0]))
         db.instance_get_by_uuid(mox.IgnoreArg(),
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(fake_inst(display_name=HOST,
@@ -1791,7 +1791,7 @@ class CommonNetworkTestCase(test.TestCase):
                                  'virtual_interface_get_by_instance')
         manager.db.virtual_interface_get_by_instance(
                 self.context, FAKEUUID,
-                use_slave=False).AndRaise(exception.InstanceNotFound(
+                use_subordinate=False).AndRaise(exception.InstanceNotFound(
                                                  instance_id=FAKEUUID))
         self.mox.ReplayAll()
         self.assertRaises(messaging.ExpectedException,

--- a/nova/tests/objects/test_instance.py
+++ b/nova/tests/objects/test_instance.py
@@ -104,7 +104,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(db, 'instance_get_by_uuid')
         db.instance_get_by_uuid(self.context, 'uuid',
                                 columns_to_join=[],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(self.fake_instance)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, 'uuid',
@@ -123,7 +123,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(
             self.context, 'uuid',
             columns_to_join=exp_cols,
-            use_slave=False
+            use_subordinate=False
             ).AndReturn(self.fake_instance)
         fake_faults = test_instance_fault.fake_faults
         db.instance_fault_get_by_instance_uuids(
@@ -155,13 +155,13 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(self.fake_instance)
         fake_inst2 = dict(self.fake_instance,
                           system_metadata=[{'key': 'foo', 'value': 'bar'}])
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['system_metadata'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst2)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid)
@@ -186,7 +186,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, 'fake-uuid',
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_instance)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, 'fake-uuid')
@@ -204,13 +204,13 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(dict(self.fake_instance,
                                                  host='orig-host'))
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(dict(self.fake_instance,
                                                  host='new-host'))
         self.mox.StubOutWithMock(instance_info_cache.InstanceInfoCache,
@@ -232,7 +232,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(instance.Instance, 'get_by_uuid')
         instance.Instance.get_by_uuid(self.context, uuid=inst.uuid,
                                       expected_attrs=['metadata'],
-                                      use_slave=False
+                                      use_subordinate=False
                                       ).AndReturn(inst_copy)
         self.mox.ReplayAll()
         self.assertRaises(exception.OrphanedObjectError, inst.refresh)
@@ -279,7 +279,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(old_ref)
         db.instance_update_and_get_original(
                 self.context, fake_uuid, expected_updates,
@@ -359,7 +359,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(old_ref)
         db.instance_update_and_get_original(
                 self.context, fake_uuid, expected_updates, update_cells=False,
@@ -372,7 +372,7 @@ class _TestInstanceObject(object):
         self.mox.ReplayAll()
 
         inst = instance.Instance.get_by_uuid(self.context, old_ref['uuid'],
-                                             use_slave=False)
+                                             use_subordinate=False)
         self.assertEqual('hello', inst.display_name)
         inst.display_name = 'goodbye'
         inst.save()
@@ -386,7 +386,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid)
@@ -400,7 +400,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid)
@@ -414,7 +414,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid)
@@ -438,7 +438,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         db.instance_info_cache_update(self.context, fake_uuid,
                                       {'network_info': nwinfo2_json})
@@ -455,7 +455,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(db, 'instance_get_by_uuid')
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid,
@@ -481,7 +481,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         db.security_group_update(self.context, 1, {'description': 'changed'}
                                  ).AndReturn(fake_inst['security_groups'][0])
@@ -506,7 +506,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid)
@@ -518,7 +518,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(db, 'instance_get_by_uuid')
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['pci_devices'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid,
@@ -564,7 +564,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(db, 'instance_get_by_uuid')
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['pci_devices'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid,
@@ -582,7 +582,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(db, 'instance_fault_get_by_instance_uuids')
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=[],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(self.fake_instance)
         db.instance_fault_get_by_instance_uuids(
             self.context, [fake_uuid]).AndReturn({fake_uuid: fake_faults})
@@ -919,11 +919,11 @@ class _TestInstanceListObject(object):
         db.instance_get_all_by_filters(self.context, {'foo': 'bar'}, 'uuid',
                                        'asc', limit=None, marker=None,
                                        columns_to_join=['metadata'],
-                                       use_slave=False).AndReturn(fakes)
+                                       use_subordinate=False).AndReturn(fakes)
         self.mox.ReplayAll()
         inst_list = instance.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, 'uuid', 'asc',
-            expected_attrs=['metadata'], use_slave=False)
+            expected_attrs=['metadata'], use_subordinate=False)
 
         for i in range(0, len(fakes)):
             self.assertIsInstance(inst_list.objects[i], instance.Instance)
@@ -940,12 +940,12 @@ class _TestInstanceListObject(object):
                                        {'deleted': True, 'cleaned': False},
                                        'uuid', 'asc', limit=None, marker=None,
                                        columns_to_join=['metadata'],
-                                       use_slave=False).AndReturn(
+                                       use_subordinate=False).AndReturn(
                                            [fakes[1]])
         self.mox.ReplayAll()
         inst_list = instance.InstanceList.get_by_filters(
             self.context, {'deleted': True, 'cleaned': False}, 'uuid', 'asc',
-            expected_attrs=['metadata'], use_slave=False)
+            expected_attrs=['metadata'], use_subordinate=False)
 
         self.assertEqual(1, len(inst_list))
         self.assertIsInstance(inst_list.objects[0], instance.Instance)
@@ -958,7 +958,7 @@ class _TestInstanceListObject(object):
         self.mox.StubOutWithMock(db, 'instance_get_all_by_host')
         db.instance_get_all_by_host(self.context, 'foo',
                                     columns_to_join=None,
-                                    use_slave=False).AndReturn(fakes)
+                                    use_subordinate=False).AndReturn(fakes)
         self.mox.ReplayAll()
         inst_list = instance.InstanceList.get_by_host(self.context, 'foo')
         for i in range(0, len(fakes)):
@@ -1046,7 +1046,7 @@ class _TestInstanceListObject(object):
         self.mox.StubOutWithMock(db, 'instance_fault_get_by_instance_uuids')
         db.instance_get_all_by_host(self.context, 'host',
                                     columns_to_join=[],
-                                    use_slave=False
+                                    use_subordinate=False
                                     ).AndReturn(fake_insts)
         db.instance_fault_get_by_instance_uuids(
             self.context, [x['uuid'] for x in fake_insts]
@@ -1054,7 +1054,7 @@ class _TestInstanceListObject(object):
         self.mox.ReplayAll()
         instances = instance.InstanceList.get_by_host(self.context, 'host',
                                                       expected_attrs=['fault'],
-                                                      use_slave=False)
+                                                      use_subordinate=False)
         self.assertEqual(2, len(instances))
         self.assertEqual(fake_faults['fake-uuid'][0],
                          dict(instances[0].fault.iteritems()))

--- a/nova/tests/objects/test_migration.py
+++ b/nova/tests/objects/test_migration.py
@@ -116,7 +116,7 @@ class _TestMigrationObject(object):
         db.instance_get_by_uuid(ctxt, fake_migration['instance_uuid'],
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         mig = migration.Migration._from_db_object(ctxt,
                                                   migration.Migration(),
@@ -133,11 +133,11 @@ class _TestMigrationObject(object):
             db, 'migration_get_unconfirmed_by_dest_compute')
         db.migration_get_unconfirmed_by_dest_compute(
             ctxt, 'window', 'foo',
-            use_slave=False).AndReturn(db_migrations)
+            use_subordinate=False).AndReturn(db_migrations)
         self.mox.ReplayAll()
         migrations = (
             migration.MigrationList.get_unconfirmed_by_dest_compute(
-                ctxt, 'window', 'foo', use_slave=False))
+                ctxt, 'window', 'foo', use_subordinate=False))
         self.assertEqual(2, len(migrations))
         for index, db_migration in enumerate(db_migrations):
             self.compare_obj(migrations[index], db_migration)

--- a/nova/tests/test_metadata.py
+++ b/nova/tests/test_metadata.py
@@ -204,7 +204,7 @@ class MetadataTestCase(test.TestCase):
                          'default_ephemeral_device': None,
                          'default_swap_device': None})
 
-        def fake_bdm_get(ctxt, uuid, use_slave=False):
+        def fake_bdm_get(ctxt, uuid, use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                     {'volume_id': 87654321,
                      'snapshot_id': None,

--- a/nova/tests/virt/libvirt/test_driver.py
+++ b/nova/tests/virt/libvirt/test_driver.py
@@ -5778,7 +5778,7 @@ class LibvirtConnTestCase(test.TestCase,
         db.instance_get_by_uuid(mox.IgnoreArg(), mox.IgnoreArg(),
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(instance)
         self.mox.StubOutWithMock(driver, "block_device_info_get_mapping")
         driver.block_device_info_get_mapping(vol

--- a/nova/tests/virt/xenapi/test_xenapi.py
+++ b/nova/tests/virt/xenapi/test_xenapi.py
@@ -1431,7 +1431,7 @@ iface eth0 inet6 static
         fake_inst2 = fake_instance.fake_db_instance(id=456)
         db.instance_get_all_by_host(self.context, fake_inst['host'],
                                     columns_to_join=None,
-                                    use_slave=False
+                                    use_subordinate=False
                                     ).AndReturn([fake_inst, fake_inst2])
         self.mox.ReplayAll()
         expected_name = CONF.instance_name_template % fake_inst['id']
@@ -1448,7 +1448,7 @@ iface eth0 inet6 static
         self.stubs.Set(db, "aggregate_get_by_host",
                        fake_aggregate_get_by_host)
 
-        self.stubs.Set(self.conn._session, "is_slave", True)
+        self.stubs.Set(self.conn._session, "is_subordinate", True)
 
         self.assertRaises(test.TestingException,
                 self.conn._session._get_host_uuid)
@@ -2903,7 +2903,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                   pool_states.POOL_FLAG: 'XenAPI'}}
         self.aggr = db.aggregate_create(self.context, values)
         self.fake_metadata = {pool_states.POOL_FLAG: 'XenAPI',
-                              'master_compute': 'host',
+                              'main_compute': 'host',
                               'availability_zone': 'fake_zone',
                               pool_states.KEY: pool_states.ACTIVE,
                               'host': xenapi_fake.get_record('host',
@@ -2913,18 +2913,18 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
 
         calls = []
 
-        def pool_add_to_aggregate(context, aggregate, host, slave_info=None):
+        def pool_add_to_aggregate(context, aggregate, host, subordinate_info=None):
             self.assertEqual("CONTEXT", context)
             self.assertEqual("AGGREGATE", aggregate)
             self.assertEqual("HOST", host)
-            self.assertEqual("SLAVEINFO", slave_info)
+            self.assertEqual("SLAVEINFO", subordinate_info)
             calls.append(pool_add_to_aggregate)
         self.stubs.Set(self.conn._pool,
                        "add_to_aggregate",
                        pool_add_to_aggregate)
 
         self.conn.add_to_aggregate("CONTEXT", "AGGREGATE", "HOST",
-                                   slave_info="SLAVEINFO")
+                                   subordinate_info="SLAVEINFO")
 
         self.assertIn(pool_add_to_aggregate, calls)
 
@@ -2933,18 +2933,18 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         calls = []
 
         def pool_remove_from_aggregate(context, aggregate, host,
-                                       slave_info=None):
+                                       subordinate_info=None):
             self.assertEqual("CONTEXT", context)
             self.assertEqual("AGGREGATE", aggregate)
             self.assertEqual("HOST", host)
-            self.assertEqual("SLAVEINFO", slave_info)
+            self.assertEqual("SLAVEINFO", subordinate_info)
             calls.append(pool_remove_from_aggregate)
         self.stubs.Set(self.conn._pool,
                        "remove_from_aggregate",
                        pool_remove_from_aggregate)
 
         self.conn.remove_from_aggregate("CONTEXT", "AGGREGATE", "HOST",
-                                        slave_info="SLAVEINFO")
+                                        subordinate_info="SLAVEINFO")
 
         self.assertIn(pool_remove_from_aggregate, calls)
 
@@ -2960,11 +2960,11 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         self.assertThat(self.fake_metadata,
                         matchers.DictMatches(result['metadetails']))
 
-    def test_join_slave(self):
-        # Ensure join_slave gets called when the request gets to master.
-        def fake_join_slave(id, compute_uuid, host, url, user, password):
-            fake_join_slave.called = True
-        self.stubs.Set(self.conn._pool, "_join_slave", fake_join_slave)
+    def test_join_subordinate(self):
+        # Ensure join_subordinate gets called when the request gets to main.
+        def fake_join_subordinate(id, compute_uuid, host, url, user, password):
+            fake_join_subordinate.called = True
+        self.stubs.Set(self.conn._pool, "_join_subordinate", fake_join_subordinate)
 
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                                           metadata=self.fake_metadata)
@@ -2974,7 +2974,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                                          user='fake_user',
                                          passwd='fake_pass',
                                          xenhost_uuid='fake_uuid'))
-        self.assertTrue(fake_join_slave.called)
+        self.assertTrue(fake_join_subordinate.called)
 
     def test_add_to_aggregate_first_host(self):
         def fake_pool_set_name_label(self, session, pool_ref, name):
@@ -3014,19 +3014,19 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                           self.conn._pool.remove_from_aggregate,
                           self.context, result, "test_host")
 
-    def test_remove_slave(self):
-        # Ensure eject slave gets called.
-        def fake_eject_slave(id, compute_uuid, host_uuid):
-            fake_eject_slave.called = True
-        self.stubs.Set(self.conn._pool, "_eject_slave", fake_eject_slave)
+    def test_remove_subordinate(self):
+        # Ensure eject subordinate gets called.
+        def fake_eject_subordinate(id, compute_uuid, host_uuid):
+            fake_eject_subordinate.called = True
+        self.stubs.Set(self.conn._pool, "_eject_subordinate", fake_eject_subordinate)
 
         self.fake_metadata['host2'] = 'fake_host2_uuid'
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                 metadata=self.fake_metadata, aggr_state=pool_states.ACTIVE)
         self.conn._pool.remove_from_aggregate(self.context, aggregate, "host2")
-        self.assertTrue(fake_eject_slave.called)
+        self.assertTrue(fake_eject_subordinate.called)
 
-    def test_remove_master_solo(self):
+    def test_remove_main_solo(self):
         # Ensure metadata are cleared after removal.
         def fake_clear_pool(id):
             fake_clear_pool.called = True
@@ -3041,8 +3041,8 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                 pool_states.KEY: pool_states.ACTIVE},
                 matchers.DictMatches(result['metadetails']))
 
-    def test_remote_master_non_empty_pool(self):
-        # Ensure AggregateError is raised if removing the master.
+    def test_remote_main_non_empty_pool(self):
+        # Ensure AggregateError is raised if removing the main.
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                                           metadata=self.fake_metadata)
 
@@ -3152,7 +3152,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                           self.compute.add_aggregate_host,
                           self.context, host="fake_host",
                           aggregate=jsonutils.to_primitive(self.aggr),
-                          slave_info=None)
+                          subordinate_info=None)
         excepted = db.aggregate_get(self.context, self.aggr['id'])
         self.assertEqual(excepted['metadetails'][pool_states.KEY],
                 pool_states.ERROR)
@@ -3164,16 +3164,16 @@ class MockComputeAPI(object):
         self._mock_calls = []
 
     def add_aggregate_host(self, ctxt, aggregate,
-                                     host_param, host, slave_info):
+                                     host_param, host, subordinate_info):
         self._mock_calls.append((
             self.add_aggregate_host, ctxt, aggregate,
-            host_param, host, slave_info))
+            host_param, host, subordinate_info))
 
     def remove_aggregate_host(self, ctxt, aggregate_id, host_param,
-                              host, slave_info):
+                              host, subordinate_info):
         self._mock_calls.append((
             self.remove_aggregate_host, ctxt, aggregate_id,
-            host_param, host, slave_info))
+            host_param, host, subordinate_info))
 
 
 class StubDependencies(object):
@@ -3188,10 +3188,10 @@ class StubDependencies(object):
     def _get_metadata(self, *_ignore):
         return {
             pool_states.KEY: {},
-            'master_compute': 'master'
+            'main_compute': 'main'
         }
 
-    def _create_slave_info(self, *ignore):
+    def _create_subordinate_info(self, *ignore):
         return "SLAVE_INFO"
 
 
@@ -3205,32 +3205,32 @@ class HypervisorPoolTestCase(test.NoDBTestCase):
         'id': 98,
         'hosts': [],
         'metadata': {
-            'master_compute': 'master',
+            'main_compute': 'main',
             pool_states.POOL_FLAG: {},
             pool_states.KEY: {}
             }
         }
 
-    def test_slave_asks_master_to_add_slave_to_pool(self):
-        slave = ResourcePoolWithStubs()
+    def test_subordinate_asks_main_to_add_subordinate_to_pool(self):
+        subordinate = ResourcePoolWithStubs()
 
-        slave.add_to_aggregate("CONTEXT", self.fake_aggregate, "slave")
+        subordinate.add_to_aggregate("CONTEXT", self.fake_aggregate, "subordinate")
 
         self.assertIn(
-            (slave.compute_rpcapi.add_aggregate_host,
+            (subordinate.compute_rpcapi.add_aggregate_host,
             "CONTEXT", jsonutils.to_primitive(self.fake_aggregate),
-            "slave", "master", "SLAVE_INFO"),
-            slave.compute_rpcapi._mock_calls)
+            "subordinate", "main", "SLAVE_INFO"),
+            subordinate.compute_rpcapi._mock_calls)
 
-    def test_slave_asks_master_to_remove_slave_from_pool(self):
-        slave = ResourcePoolWithStubs()
+    def test_subordinate_asks_main_to_remove_subordinate_from_pool(self):
+        subordinate = ResourcePoolWithStubs()
 
-        slave.remove_from_aggregate("CONTEXT", self.fake_aggregate, "slave")
+        subordinate.remove_from_aggregate("CONTEXT", self.fake_aggregate, "subordinate")
 
         self.assertIn(
-            (slave.compute_rpcapi.remove_aggregate_host,
-            "CONTEXT", 98, "slave", "master", "SLAVE_INFO"),
-            slave.compute_rpcapi._mock_calls)
+            (subordinate.compute_rpcapi.remove_aggregate_host,
+            "CONTEXT", 98, "subordinate", "main", "SLAVE_INFO"),
+            subordinate.compute_rpcapi._mock_calls)
 
 
 class SwapXapiHostTestCase(test.NoDBTestCase):

--- a/nova/virt/xenapi/client/session.py
+++ b/nova/virt/xenapi/client/session.py
@@ -77,7 +77,7 @@ class XenAPISession(object):
         import XenAPI
         self.XenAPI = XenAPI
         self._sessions = queue.Queue()
-        self.is_slave = False
+        self.is_subordinate = False
         exception = self.XenAPI.Failure(_("Unable to log in to XenAPI "
                                           "(is the Dom0 disk full?)"))
         url = self._create_first_session(url, user, pw, exception)
@@ -107,13 +107,13 @@ class XenAPISession(object):
             with timeout.Timeout(CONF.xenserver.login_timeout, exception):
                 session.login_with_password(user, pw)
         except self.XenAPI.Failure as e:
-            # if user and pw of the master are different, we're doomed!
+            # if user and pw of the main are different, we're doomed!
             if e.details[0] == 'HOST_IS_SLAVE':
-                master = e.details[1]
-                url = pool.swap_xapi_host(url, master)
+                main = e.details[1]
+                url = pool.swap_xapi_host(url, main)
                 session = self.XenAPI.Session(url)
                 session.login_with_password(user, pw)
-                self.is_slave = True
+                self.is_subordinate = True
             else:
                 raise
         self._sessions.put(session)
@@ -127,7 +127,7 @@ class XenAPISession(object):
             self._sessions.put(session)
 
     def _get_host_uuid(self):
-        if self.is_slave:
+        if self.is_subordinate:
             aggr = objects.AggregateList.get_by_host(
                 context.get_admin_context(),
                 CONF.host, key=pool_states.POOL_FLAG)[0]

--- a/nova/virt/xenapi/fake.py
+++ b/nova/virt/xenapi/fake.py
@@ -113,7 +113,7 @@ def create_host(name_label, hostname='fake_name', address='fake_addr'):
     # Create a pool if we don't have one already
     if len(_db_content['pool']) == 0:
         pool_ref = _create_pool('')
-        _db_content['pool'][pool_ref]['master'] = host_ref
+        _db_content['pool'][pool_ref]['main'] = host_ref
         _db_content['pool'][pool_ref]['default-SR'] = host_default_sr_ref
         _db_content['pool'][pool_ref]['suspend-image-SR'] = host_default_sr_ref
 
@@ -841,7 +841,7 @@ class SessionBase(object):
             return self._session
         elif name == 'xenapi':
             return _Dispatcher(self.xenapi_request, None)
-        elif name.startswith('login') or name.startswith('slave_local'):
+        elif name.startswith('login') or name.startswith('subordinate_local'):
             return lambda *params: self._login(name, params)
         elif name.startswith('Async'):
             return lambda *params: self._async(name, params)

--- a/nova/virt/xenapi/pool.py
+++ b/nova/virt/xenapi/pool.py
@@ -65,7 +65,7 @@ class ResourcePool(object):
                             'during operation on %(host)s'),
                           {'aggregate_id': aggregate['id'], 'host': host})
 
-    def add_to_aggregate(self, context, aggregate, host, slave_info=None):
+    def add_to_aggregate(self, context, aggregate, host, subordinate_info=None):
         """Add a compute host to an aggregate."""
         if not pool_states.is_hv_pool(aggregate['metadata']):
             return
@@ -83,38 +83,38 @@ class ResourcePool(object):
         if (aggregate['metadata'][pool_states.KEY] == pool_states.CREATED):
             aggregate.update_metadata({pool_states.KEY: pool_states.CHANGING})
         if len(aggregate['hosts']) == 1:
-            # this is the first host of the pool -> make it master
+            # this is the first host of the pool -> make it main
             self._init_pool(aggregate['id'], aggregate['name'])
-            # save metadata so that we can find the master again
-            metadata = {'master_compute': host,
+            # save metadata so that we can find the main again
+            metadata = {'main_compute': host,
                         host: self._host_uuid,
                         pool_states.KEY: pool_states.ACTIVE}
             aggregate.update_metadata(metadata)
         else:
             # the pool is already up and running, we need to figure out
             # whether we can serve the request from this host or not.
-            master_compute = aggregate['metadata']['master_compute']
-            if master_compute == CONF.host and master_compute != host:
-                # this is the master ->  do a pool-join
-                # To this aim, nova compute on the slave has to go down.
+            main_compute = aggregate['metadata']['main_compute']
+            if main_compute == CONF.host and main_compute != host:
+                # this is the main ->  do a pool-join
+                # To this aim, nova compute on the subordinate has to go down.
                 # NOTE: it is assumed that ONLY nova compute is running now
-                self._join_slave(aggregate['id'], host,
-                                 slave_info.get('compute_uuid'),
-                                 slave_info.get('url'), slave_info.get('user'),
-                                 slave_info.get('passwd'))
-                metadata = {host: slave_info.get('xenhost_uuid'), }
+                self._join_subordinate(aggregate['id'], host,
+                                 subordinate_info.get('compute_uuid'),
+                                 subordinate_info.get('url'), subordinate_info.get('user'),
+                                 subordinate_info.get('passwd'))
+                metadata = {host: subordinate_info.get('xenhost_uuid'), }
                 aggregate.update_metadata(metadata)
-            elif master_compute and master_compute != host:
-                # send rpc cast to master, asking to add the following
+            elif main_compute and main_compute != host:
+                # send rpc cast to main, asking to add the following
                 # host with specified credentials.
-                slave_info = self._create_slave_info()
+                subordinate_info = self._create_subordinate_info()
 
                 self.compute_rpcapi.add_aggregate_host(
-                    context, aggregate, host, master_compute, slave_info)
+                    context, aggregate, host, main_compute, subordinate_info)
 
-    def remove_from_aggregate(self, context, aggregate, host, slave_info=None):
+    def remove_from_aggregate(self, context, aggregate, host, subordinate_info=None):
         """Remove a compute host from an aggregate."""
-        slave_info = slave_info or dict()
+        subordinate_info = subordinate_info or dict()
         if not pool_states.is_hv_pool(aggregate['metadata']):
             return
 
@@ -127,19 +127,19 @@ class ResourcePool(object):
                     aggregate_id=aggregate['id'],
                     reason=invalid[aggregate['metadata'][pool_states.KEY]])
 
-        master_compute = aggregate['metadata']['master_compute']
-        if master_compute == CONF.host and master_compute != host:
-            # this is the master -> instruct it to eject a host from the pool
+        main_compute = aggregate['metadata']['main_compute']
+        if main_compute == CONF.host and main_compute != host:
+            # this is the main -> instruct it to eject a host from the pool
             host_uuid = aggregate['metadata'][host]
-            self._eject_slave(aggregate['id'],
-                              slave_info.get('compute_uuid'), host_uuid)
+            self._eject_subordinate(aggregate['id'],
+                              subordinate_info.get('compute_uuid'), host_uuid)
             aggregate.update_metadata({host: None})
-        elif master_compute == host:
-            # Remove master from its own pool -> destroy pool only if the
-            # master is on its own, otherwise raise fault. Destroying a
-            # pool made only by master is fictional
+        elif main_compute == host:
+            # Remove main from its own pool -> destroy pool only if the
+            # main is on its own, otherwise raise fault. Destroying a
+            # pool made only by main is fictional
             if len(aggregate['hosts']) > 1:
-                # NOTE: this could be avoided by doing a master
+                # NOTE: this could be avoided by doing a main
                 # re-election, but this is simpler for now.
                 raise exception.InvalidAggregateAction(
                                     aggregate_id=aggregate['id'],
@@ -148,32 +148,32 @@ class ResourcePool(object):
                                              'from the pool; pool not empty')
                                              % host)
             self._clear_pool(aggregate['id'])
-            aggregate.update_metadata({'master_compute': None, host: None})
-        elif master_compute and master_compute != host:
-            # A master exists -> forward pool-eject request to master
-            slave_info = self._create_slave_info()
+            aggregate.update_metadata({'main_compute': None, host: None})
+        elif main_compute and main_compute != host:
+            # A main exists -> forward pool-eject request to main
+            subordinate_info = self._create_subordinate_info()
 
             self.compute_rpcapi.remove_aggregate_host(
-                context, aggregate['id'], host, master_compute, slave_info)
+                context, aggregate['id'], host, main_compute, subordinate_info)
         else:
             # this shouldn't have happened
             raise exception.AggregateError(aggregate_id=aggregate['id'],
                                            action='remove_from_aggregate',
                                            reason=_('Unable to eject %s '
-                                           'from the pool; No master found')
+                                           'from the pool; No main found')
                                            % host)
 
-    def _join_slave(self, aggregate_id, host, compute_uuid, url, user, passwd):
-        """Joins a slave into a XenServer resource pool."""
+    def _join_subordinate(self, aggregate_id, host, compute_uuid, url, user, passwd):
+        """Joins a subordinate into a XenServer resource pool."""
         try:
             args = {'compute_uuid': compute_uuid,
                     'url': url,
                     'user': user,
                     'password': passwd,
                     'force': jsonutils.dumps(CONF.xenserver.use_join_force),
-                    'master_addr': self._host_addr,
-                    'master_user': CONF.xenserver.connection_username,
-                    'master_pass': CONF.xenserver.connection_password, }
+                    'main_addr': self._host_addr,
+                    'main_user': CONF.xenserver.connection_username,
+                    'main_pass': CONF.xenserver.connection_password, }
             self._session.call_plugin('xenhost', 'host_join', args)
         except self._session.XenAPI.Failure as e:
             LOG.error(_("Pool-Join failed: %s"), e)
@@ -182,8 +182,8 @@ class ResourcePool(object):
                                            reason=_('Unable to join %s '
                                                   'in the pool') % host)
 
-    def _eject_slave(self, aggregate_id, compute_uuid, host_uuid):
-        """Eject a slave from a XenServer resource pool."""
+    def _eject_subordinate(self, aggregate_id, compute_uuid, host_uuid):
+        """Eject a subordinate from a XenServer resource pool."""
         try:
             # shutdown nova-compute; if there are other VMs running, e.g.
             # guest instances, the eject will fail. That's a precaution
@@ -222,7 +222,7 @@ class ResourcePool(object):
                                            action='remove_from_aggregate',
                                            reason=str(e.details))
 
-    def _create_slave_info(self):
+    def _create_subordinate_info(self):
         """XenServer specific info needed to join the hypervisor pool."""
         # replace the address from the xenapi connection url
         # because this might be 169.254.0.1, i.e. xenapi

--- a/nova/virt/xenapi/pool_states.py
+++ b/nova/virt/xenapi/pool_states.py
@@ -25,7 +25,7 @@ cases.
 A 'created' pool becomes 'changing' during the first request of
 adding a host. During a 'changing' status no other requests will be accepted;
 this is to allow the hypervisor layer to instantiate the underlying pool
-without any potential race condition that may incur in master/slave-based
+without any potential race condition that may incur in main/subordinate-based
 configurations. The pool goes into the 'active' state when the underlying
 pool has been correctly instantiated.
 All other operations (e.g. add/remove hosts) that succeed will keep the

--- a/tools/db/schema_diff.py
+++ b/tools/db/schema_diff.py
@@ -33,12 +33,12 @@ Run like:
     MYSQL:
 
     ./tools/db/schema_diff.py mysql://root@localhost \
-                              master:latest my_branch:82
+                              main:latest my_branch:82
 
     POSTGRESQL:
 
     ./tools/db/schema_diff.py postgresql://localhost \
-                              master:latest my_branch:82
+                              main:latest my_branch:82
 """
 
 from __future__ import print_function
@@ -225,12 +225,12 @@ def parse_options():
     try:
         orig_branch, orig_version = sys.argv[2].split(':')
     except IndexError:
-        usage('original branch and version required (e.g. master:82)')
+        usage('original branch and version required (e.g. main:82)')
 
     try:
         new_branch, new_version = sys.argv[3].split(':')
     except IndexError:
-        usage('new branch and version required (e.g. master:82)')
+        usage('new branch and version required (e.g. main:82)')
 
     return db_url, orig_branch, orig_version, new_branch, new_version
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.